### PR TITLE
Keep the live mail host out of the repo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 
 # Base URL of your Stalwart server (scheme + host, no path). ihasmail discovers
 # the JMAP session at <STALWART_URL>/.well-known/jmap.
-STALWART_URL=https://mail.inbuxa.com
+STALWART_URL=https://mail.example.com
 
 # Random secret used to derive encryption keys for persisted sessions.
 # Generate with: openssl rand -base64 48

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Requirements: Node ≥ 20.10 (22 recommended), npm ≥ 10.
 ```bash
 npm install
 
-# against a real Stalwart (default: mail.inbuxa.com, change STALWART_URL in .env or the environment)
+# against a real Stalwart (set STALWART_URL in .env or the environment)
 npm run dev            # server on :8080 (tsx watch) + Vite dev server on :5173 (proxying /api)
 
 # against the built-in mock Stalwart (demo@example.com / demo) — no real mailbox needed
@@ -110,7 +110,7 @@ All configuration is via environment variables (see `.env.example`):
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `STALWART_URL` | `https://mail.inbuxa.com` | Base URL of Stalwart; the JMAP session is discovered at `/.well-known/jmap` |
+| `STALWART_URL` | `https://mail.example.com` | Base URL of Stalwart; the JMAP session is discovered at `/.well-known/jmap` |
 | `APP_SECRET` | *(required in production)* | Secret used to derive session encryption keys |
 | `PORT` / `HOST` | `8080` / `0.0.0.0` | Listen address |
 | `TRUST_PROXY` | `1` | Honour `X-Forwarded-*` from a reverse proxy |
@@ -127,7 +127,7 @@ Press `?` anywhere. Highlights: `c` compose · `/` search · `j`/`k` navigate ·
 
 ## Known issues / pending QA
 
-Verified against the mock server and, for the core mail flows, against a live Stalwart 1.0 (`mail.inbuxa.com`). Still pending live verification:
+Verified against the mock server and, for the core mail flows, against a live Stalwart 1.0. Still pending live verification:
 
 - **HTML signatures** — Stalwart caps identity signatures at 2 KB. ihasmail compacts pasted HTML, moves images to Files and, if still too large, keeps the full signature in Files behind a short marker (other clients see a text fallback). The end-to-end flow (save → compose → send with inline logo) is implemented but not yet confirmed on the live server.
 - **Files** — the live server runs an older Stalwart build than `main`; `FileNode/query` there rejects `isTopLevel`/`parentId` filters, so ihasmail falls back to listing all nodes and building the tree client-side. Upload/rename/move/delete still need a live pass.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "8080:8080"
     environment:
-      STALWART_URL: ${STALWART_URL:-https://mail.inbuxa.com}
+      STALWART_URL: ${STALWART_URL:?set STALWART_URL in .env}
       APP_SECRET: ${APP_SECRET:?set APP_SECRET in .env (openssl rand -base64 48)}
       APP_NAME: ${APP_NAME:-ihasmail}
       TRUST_PROXY: "1"

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -55,7 +55,7 @@ if (!appSecret || appSecret === "change-me") {
   );
 }
 
-const stalwartUrl = env("STALWART_URL", "https://mail.inbuxa.com").replace(/\/+$/, "");
+const stalwartUrl = env("STALWART_URL", "https://mail.example.com").replace(/\/+$/, "");
 
 export const config = {
   isProd,


### PR DESCRIPTION
Replaces the hard-coded QA mail host with generic placeholders.

| Where | Before | After |
| --- | --- | --- |
| `server/src/config.ts` | default `https://mail.inbuxa.com` | default `https://mail.example.com` |
| `.env.example` | the real host | `https://mail.example.com` |
| `docker-compose.yml` | `${STALWART_URL:-<real host>}` | `${STALWART_URL:?set STALWART_URL in .env}` — required, like `APP_SECRET` |
| `README.md` (×3) | named the host in the dev command, the config table and the QA note | placeholders / no host named |

**Nothing deployed depends on the old default** — the running container passes `STALWART_URL` explicitly via `--env-file`, so this changes no behaviour there. It does mean `docker compose up` without a configured `STALWART_URL` now fails with a clear message instead of silently pointing at someone else's mail server, which seems strictly better.

Note that this only covers the working tree. The hostname is still present in two historical commits (`ff46689`, `5db39e4`); removing it from history is a separate, destructive decision — see the discussion on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)