### PR TITLE
Stop calling every event a series

### DIFF
--- a/web/src/store/__tests__/recurrence.test.ts
+++ b/web/src/store/__tests__/recurrence.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { isRecurring } from "@/store/calendar";
+import type { CalendarEvent } from "@/jmap/types";
+
+/**
+ * `CalendarEvent/query` runs with `expandRecurrences`, and Stalwart puts a
+ * `baseEventId` on everything it returns that way — one-off events included.
+ * Treating that as proof of a series told people editing a plain event that
+ * their changes applied to the whole series, and offered to delete "all
+ * occurrences" of an event that has exactly one.
+ */
+const ev = (p: Partial<CalendarEvent>): CalendarEvent => ({ id: "ev1", "@type": "Event", uid: "u1", calendarIds: { c1: true }, start: "2026-08-25T09:00:00", duration: "PT30M", ...p } as CalendarEvent);
+
+describe("isRecurring", () => {
+  it("does not call a one-off event a series just because it has a baseEventId", () => {
+    expect(isRecurring(ev({ baseEventId: "ev1" }))).toBe(false);
+    expect(isRecurring(ev({}))).toBe(false);
+  });
+  it("still recognises an occurrence whose base is another event", () => {
+    expect(isRecurring(ev({ id: "ev1_2", baseEventId: "ev1" }))).toBe(true);
+  });
+  it("recognises a series by its recurrence rules", () => {
+    expect(isRecurring(ev({ recurrenceRules: [{ "@type": "RecurrenceRule", frequency: "weekly" }] }))).toBe(true);
+    expect(isRecurring(ev({ baseEventId: "ev1", recurrenceRules: [{ "@type": "RecurrenceRule", frequency: "daily" }] }))).toBe(true);
+    expect(isRecurring(ev({ excludedRecurrenceRules: [{ "@type": "RecurrenceRule", frequency: "monthly" }] }))).toBe(true);
+  });
+});

--- a/web/src/store/calendar.ts
+++ b/web/src/store/calendar.ts
@@ -297,6 +297,20 @@ export const useCalendar = create<CalendarState>((set, get) => ({
   },
 }));
 
+/**
+ * Whether an event is part of a series.
+ *
+ * Not the same question as "does it have a baseEventId": `CalendarEvent/query`
+ * runs with `expandRecurrences`, and Stalwart sets `baseEventId` on every event
+ * it returns that way — a one-off event included, pointing at itself. Recurrence
+ * rules are what make a series, so those are the question; a base that is some
+ * *other* event means this is one occurrence of one, whether or not the expanded
+ * instance carried the rules along with it.
+ */
+export function isRecurring(ev: CalendarEvent): boolean {
+  return Boolean(ev.recurrenceRules?.length || ev.excludedRecurrenceRules?.length || (ev.baseEventId && ev.baseEventId !== ev.id));
+}
+
 export function toInstance(e: CalendarEvent, calendars: Record<Id, Calendar>): EventInstance | null {
   const allDay = Boolean(e.showWithoutTime);
   let start: Date;

--- a/web/src/views/calendar/CalendarContextMenu.tsx
+++ b/web/src/views/calendar/CalendarContextMenu.tsx
@@ -1,7 +1,7 @@
 import { Calendar as CalIcon, CalendarDays, Copy, ExternalLink, Palette, Pencil, Plus, Tag, Trash2, X } from "lucide-react";
 import { useLocation } from "wouter";
 import type { CalendarEvent } from "@/jmap/types";
-import { useCalendar, type EventInstance } from "@/store/calendar";
+import { useCalendar, isRecurring, type EventInstance } from "@/store/calendar";
 import { useSettings } from "@/store/settings";
 import { formatDayMonth } from "@/lib/datetime";
 import { MenuItem, MenuSep, MenuTitle, Popover, type Anchor } from "@/ui/popover";
@@ -89,7 +89,7 @@ export function CalendarContextMenu({ ctx, onClose, onOpen, onEdit, onCreate }: 
   };
   const del = async () => {
     onClose();
-    const recurring = Boolean(ev.recurrenceRules?.length || ev.baseEventId);
+    const recurring = isRecurring(ev);
     if (!(await confirmDialog({ title: recurring ? "Delete all occurrences?" : "Delete this event?", confirmLabel: "Delete", danger: true }))) return;
     try {
       await cal.destroyEvent(baseId, participants > 1);

--- a/web/src/views/calendar/EventEditor.tsx
+++ b/web/src/views/calendar/EventEditor.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { Plus, Trash2, Users } from "lucide-react";
 import type { BusyPeriod, CalendarEvent, EmailAddress, JSCalendarAlert, JSCalendarParticipant, JSCalendarRecurrenceRule, JSCalendarNDay } from "@/jmap/types";
-import { useCalendar, myParticipantKeys } from "@/store/calendar";
+import { useCalendar, myParticipantKeys, isRecurring } from "@/store/calendar";
 import { useSettings } from "@/store/settings";
 import { useSession } from "@/store/session";
 import { useContacts } from "@/store/contacts";
@@ -202,7 +202,7 @@ function EventForm({ init, base, editing, onClose, settingsTz, defaultAlert, myE
   return (
     <Dialog open onClose={onClose} title={editing ? "Edit event" : "New event"} size="lg" footer={<><button className="btn" onClick={onClose}>Cancel</button><button className="btn btn-primary" disabled={busy} onClick={() => void save()}>{busy ? "Saving…" : editing ? "Save" : attendees.length && sendInvites ? "Send invites" : "Create"}</button></>}>
       <div className="event-form">
-        {init.event?.baseEventId && <div className="info-box mb-16">This is a recurring event — changes apply to the whole series.</div>}
+        {ev && isRecurring(ev) && <div className="info-box mb-16">This is a recurring event — changes apply to the whole series.</div>}
         <div className="field"><input className="input" style={{ fontSize: "1.1em", height: 44 }} placeholder="Add title" autoFocus value={title} onChange={(e) => setTitle(e.target.value)} /></div>
         <div className="time-row mb-8">
           {allDay ? (

--- a/web/src/views/calendar/EventPopover.tsx
+++ b/web/src/views/calendar/EventPopover.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { AlignLeft, Bell, Calendar as CalIcon, Check, Clock, HelpCircle, Link2, MapPin, Pencil, Repeat, Trash2, Users, X, Mail } from "lucide-react";
-import { useCalendar, myParticipantKeys, type EventInstance } from "@/store/calendar";
+import { useCalendar, myParticipantKeys, isRecurring, type EventInstance } from "@/store/calendar";
 import { Popover, type Anchor } from "@/ui/popover";
 import { confirmDialog } from "@/ui/dialog";
 import { toast } from "@/ui/toast";
@@ -29,7 +29,7 @@ export function EventPopover({ inst, anchor, onClose, onEdit }: { inst: EventIns
   const openCompose = useCompose((s) => s.open);
 
   const del = async () => {
-    const recurring = Boolean(ev.recurrenceRules?.length || ev.baseEventId);
+    const recurring = isRecurring(ev);
     const ok = await confirmDialog({ title: recurring ? "Delete all occurrences?" : "Delete this event?", message: recurring ? "This will delete the entire series." : undefined, confirmLabel: "Delete", danger: true });
     if (!ok) return;
     setBusy(true);


### PR DESCRIPTION
Fixes #25, including the addendum about the delete dialog.

Editing a one-time event showed "This is a recurring event — changes apply to the whole series", and deleting one asked "Delete all occurrences?" / "This will delete the entire series" for an event that has exactly one.

Three places treated the presence of `baseEventId` as proof of recurrence:

- `EventEditor.tsx` — the info box
- `EventPopover.tsx` — the delete confirmation
- `CalendarContextMenu.tsx` — the same confirmation from the right-click menu

That is not what the field means. `loadRange` queries with `expandRecurrences: true`, and Stalwart sets `baseEventId` on everything it returns that way — a one-off event included, pointing at itself. The mock never sets the field at all, which is why nothing caught this until it met a real server.

All three now share `isRecurring()` in `store/calendar.ts`. It asks about recurrence rules, which are what actually make a series, and also treats a base that is a *different* event as an occurrence of one — so if an expanded instance ever arrives without its rules attached, the delete dialog still tells the truth about what it is deleting. Deletion behaviour is unchanged; only the wording was wrong.

One thing worth a glance against the live 0.16.19 when convenient: this assumes Stalwart gives a non-recurring event a `baseEventId` equal to its own id, rather than minting a synthetic instance id for it. That matches the reported symptom and the spec reading. If it turns out to mint one, the one-off case needs the rules check alone — the test file has both shapes written out.

Tested: `npm run typecheck`, `npm test` (184 web + 88 server, all passing), with a new `store/__tests__/recurrence.test.ts` covering a one-off with a self-referential base, a bare event, a series by rules, and an occurrence whose base is another event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)