### PR TITLE
Fill a coloured folder in, rather than outlining it

### DIFF
--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -327,8 +327,10 @@ img { max-width: 100%; }
 /* A folder colour tints its icon; the label keeps the sidebar's contrast. */
 .folder-row .folder-icon { display: inline-flex; align-items: center; }
 /* .nav-item svg sets colour on the svg itself, so inheriting from the span is
-   not enough -- the icon has to be targeted directly to win the cascade. */
-.folder-row .folder-icon[style*="--folder-color"] svg { color: var(--folder-color); }
+   not enough -- the icon has to be targeted directly to win the cascade.
+   The fill overrides lucide's own fill="none": a CSS rule beats a presentation
+   attribute, and a solid folder reads at a glance where an outline does not. */
+.folder-row .folder-icon[style*="--folder-color"] svg { color: var(--bg); fill: var(--folder-color); }
 /* The Folders heading doubles as the way back to the top level while dragging. */
 .nav-section.drop-target { background: var(--accent-soft); outline: 2px dashed var(--accent); outline-offset: -2px; border-radius: var(--radius-sm); color: var(--accent-soft-fg); }
 .nav-item svg { flex: 0 0 auto; color: var(--fg-muted); }


### PR DESCRIPTION
A tinted outline barely registered against the sidebar. The icon is now **filled** with the colour, which is what makes it findable at a glance in a list of a dozen folders.

CSS only — four lines, no logic touched.

## Two details it needed

**The fill has to come from CSS.** Lucide writes `fill="none"` as a presentation attribute on the `svg`, and a CSS rule beats a presentation attribute — so `fill: var(--folder-color)` wins where an inline style fight would have been awkward.

**The strokes are drawn in `--bg`, not the colour.** My first attempt filled *and* stroked in the same colour, which swallowed the detail inside any icon that has some: **Archive** lost the lid and handle of its box and became an orange blob. Knocking the strokes out against the background restores them, and because it uses the `--bg` token rather than a pinned colour it inverts correctly in the light theme instead of vanishing.

## Verified

By pixels and by eye, in both themes. The coloured area of the icon went from an outline to **55% of its box**. Archive, Newsletters and Work are all still recognisably themselves rather than three coloured lozenges — the failure mode I'd have shipped without looking at it.

`npm run typecheck`, `npm test` — 224 web + 88 server passing, unchanged, since this touches no logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)