### PR TITLE
Make the AGPL's source offer point at the source being run

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,9 @@ IMAGE_PROXY=1
 
 # Branding
 APP_NAME=ihasmail
+
+# Where this instance's source can be had. ihasmail is AGPL-3.0-or-later, which
+# asks whoever runs a modified version to offer *that* version's source -- so if
+# you have patched it, point this at your own tree. Shown on the sign-in page
+# and in Settings > About.
+SOURCE_URL=https://github.com/LINUXexpert-org/ihasmail

--- a/README.md
+++ b/README.md
@@ -233,3 +233,8 @@ nearly always run as a network service rather than handed to anyone as a
 binary, and the AGPL's section 13 closes that gap: anyone running a modified
 ihasmail for other people has to offer them its source, which the GPL alone
 does not require.
+
+That offer has to point at *your* source, not this one. If you run a modified
+ihasmail, set `SOURCE_URL` to your own repository: the sign-in page and
+Settings › About both show it, so the people using your instance are told where
+the code they are actually running can be found.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       STALWART_URL: ${STALWART_URL:?set STALWART_URL in .env}
       APP_SECRET: ${APP_SECRET:?set APP_SECRET in .env (openssl rand -base64 48)}
       APP_NAME: ${APP_NAME:-ihasmail}
+      SOURCE_URL: ${SOURCE_URL:-https://github.com/LINUXexpert-org/ihasmail}
       TRUST_PROXY: "1"
       IMAGE_PROXY: "1"
     volumes:

--- a/server/package.json
+++ b/server/package.json
@@ -2,6 +2,7 @@
   "name": "@ihasmail/server",
   "version": "2.0.0",
   "private": true,
+  "license": "AGPL-3.0-or-later",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -148,6 +148,7 @@ export function createApp(): Hono<Env> {
   api.get("/config", (c) =>
     c.json({
       appName: config.appName,
+      sourceUrl: config.sourceUrl,
       imageProxy: config.imageProxy,
       maxUploadBytes: config.maxUploadBytes,
     }),
@@ -581,6 +582,7 @@ function sessionExtras(session: LiveSession, info: AccountInfo = { locale: null,
   return {
     ihasmail: {
       appName: config.appName,
+      sourceUrl: config.sourceUrl,
       imageProxy: config.imageProxy,
       maxUploadBytes: config.maxUploadBytes,
       sessionId: session.id,

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -60,6 +60,14 @@ const stalwartUrl = env("STALWART_URL", "https://mail.example.com").replace(/\/+
 export const config = {
   isProd,
   appName: env("APP_NAME", "ihasmail"),
+  /**
+   * Where this instance's source can be had, shown to everyone who reaches it.
+   *
+   * The AGPL asks whoever *runs* a modified version to offer that version's
+   * source, not the one it was forked from -- so anyone deploying a patched
+   * ihasmail should point this at their own tree.
+   */
+  sourceUrl: env("SOURCE_URL", "https://github.com/LINUXexpert-org/ihasmail"),
   host: env("HOST", "0.0.0.0"),
   port: int("PORT", 8080),
   stalwartUrl,

--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,7 @@
   "name": "@ihasmail/web",
   "version": "2.0.0",
   "private": true,
+  "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/jmap/types.ts
+++ b/web/src/jmap/types.ts
@@ -25,6 +25,8 @@ export interface JmapSession {
   state: string;
   ihasmail?: {
     appName: string;
+    /** Where this instance's source can be had, for the AGPL's sake. */
+    sourceUrl?: string;
     imageProxy: boolean;
     maxUploadBytes: number;
     sessionId: string;

--- a/web/src/lib/source.ts
+++ b/web/src/lib/source.ts
@@ -1,0 +1,8 @@
+/**
+ * Where to point someone who wants this instance's source.
+ *
+ * The AGPL asks whoever runs a modified version to offer *that* version's
+ * source. The server says where its own lives, via SOURCE_URL; this is only the
+ * fallback for when it has not been asked yet, or has nothing to say.
+ */
+export const DEFAULT_SOURCE_URL = "https://github.com/LINUXexpert-org/ihasmail";

--- a/web/src/views/Login.tsx
+++ b/web/src/views/Login.tsx
@@ -1,10 +1,23 @@
-import { useState, type FormEvent } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 import { Eye, EyeOff, LogIn, ShieldCheck } from "lucide-react";
 import { useSession } from "@/store/session";
 import { ApiError } from "@/jmap/client";
+import { DEFAULT_SOURCE_URL } from "@/lib/source";
 
 export function LoginPage() {
   const login = useSession((s) => s.login);
+  // The AGPL's offer has to reach everyone who interacts with the app over the
+  // network, and that includes whoever is looking at this form. The server says
+  // where its own source lives, so a modified deployment points at its own.
+  const [sourceUrl, setSourceUrl] = useState(DEFAULT_SOURCE_URL);
+  useEffect(() => {
+    let live = true;
+    fetch("/api/config")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((c) => { if (live && c?.sourceUrl) setSourceUrl(c.sourceUrl as string); })
+      .catch(() => { /* the default stands */ });
+    return () => { live = false; };
+  }, []);
   const [username, setUsername] = useState(() => localStorage.getItem("ihasmail:lastUser") ?? "");
   const [password, setPassword] = useState("");
   const [totp, setTotp] = useState("");
@@ -81,6 +94,8 @@ export function LoginPage() {
         </button>
         <p className="foot">
           ihasmail by <a href="https://linuxexpert.org" target="_blank" rel="noopener noreferrer">linuxexpert.org</a>
+          {" · "}
+          <a href={sourceUrl} target="_blank" rel="noopener noreferrer">AGPL-3.0 source</a>
         </p>
       </form>
     </div>

--- a/web/src/views/settings/AboutSettings.tsx
+++ b/web/src/views/settings/AboutSettings.tsx
@@ -1,9 +1,12 @@
 import { useSession } from "@/store/session";
 import { client } from "@/jmap/client";
+import { DEFAULT_SOURCE_URL } from "@/lib/source";
 
 export function AboutSettings() {
   const session = useSession((s) => s.session);
   const caps = Object.keys(session?.capabilities ?? {});
+  // A deployment running modified code should offer its own source, not ours.
+  const sourceUrl = session?.ihasmail?.sourceUrl ?? DEFAULT_SOURCE_URL;
   return (
     <div>
       <h1>About ihasmail</h1>
@@ -12,7 +15,7 @@ export function AboutSettings() {
         <img src="/img/logo.png" alt="ihasmail" width={96} />
         <div>
           <div style={{ fontWeight: 700, fontSize: "1.2em" }}>ihasmail 2.0</div>
-          <div className="hint">AGPL-3.0-or-later · <a href="https://github.com/LINUXexpert-org/ihasmail" target="_blank" rel="noreferrer">github.com/LINUXexpert-org/ihasmail</a></div>
+          <div className="hint">AGPL-3.0-or-later · <a href={sourceUrl} target="_blank" rel="noreferrer">{sourceUrl.replace(/^https?:\/\//, "")}</a></div>
         </div>
       </div>
       <h2>Server</h2>


### PR DESCRIPTION
Fixes the three findings from the licence audit. None is a conflict — the audit came back clean on everything that could have been one — but all three are ways the AGPL fails to stick in practice.

## What the audit found clean

- `LICENSE` is the full AGPL-3.0 text, §13 present; root `package.json` and the README agree.
- **All 182 installed packages are permissive**: MIT 155, ISC 13, Apache-2.0 5, BSD-2/3 4, plus `MIT-0`, `0BSD`, `Unlicense` (wouter), `CC-BY-4.0` (caniuse-lite, build data) and dompurify's `MPL-2.0 OR Apache-2.0`. No GPL-2.0-only, no LGPL, no SSPL/BUSL, nothing proprietary or unlicensed.
- **Relicensing authority holds** — only `John Ellis` and `LINUXexpert.org` have authored code, so GPL-3.0 → AGPL-3.0 was yours to make.
- **Third-party attribution already ships**: 137 `@license`/copyright comments survive in the built JS and 168 `LICENSE` files ride along in the image. (I assumed this was a gap and was wrong.)

## The three fixes

**1. The offer was hard-coded to this repository.** §13 asks whoever *runs* a modified version to offer **that** version's source. Every deployment carrying a patch was pointing at the wrong tree, and would have kept doing so unless its operator noticed and edited `AboutSettings.tsx`. `SOURCE_URL` now sets it, beside `APP_NAME`, and both the sign-in page and About read it. Documented in `.env.example`, `docker-compose.yml` and the README.

**2. The offer was only visible after signing in.** Whoever is looking at the sign-in form is interacting with the program over a network too. The footer carries it now, fetched from `/api/config` so it is right even before there is a session.

**3. The two workspace packages declared no licence.** Private, so npm never minded, but anything reading the tree saw a blank where the rest of the project says `AGPL-3.0-or-later`.

## Verified both ways round

| `SOURCE_URL` | sign-in page | Settings › About |
| --- | --- | --- |
| `https://example.org/my-fork` | `AGPL-3.0 source → example.org/my-fork` | `example.org/my-fork` |
| unset | `AGPL-3.0 source → github.com/LINUXexpert-org/ihasmail` | `github.com/LINUXexpert-org/ihasmail` |

`npm run typecheck`, `npm test` — 224 web + 88 server passing.

## Left alone, deliberately

The runtime image ships **devDependencies** — `npm ci` without `--omit=dev`, then the whole `node_modules` is copied. Not a licence problem (all permissive, notices included) but vite, typescript and vitest are sitting in production. That is a size and attack-surface question rather than a legal one, so it belongs in its own change.

Per-file AGPL headers are still absent. Not required; the FSF only recommends them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)