### PR TITLE
Trim the badges to three, and credit LINUXexpert.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,9 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/LINUXexpert-org/ihasmail/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/LINUXexpert-org/ihasmail/actions/workflows/ci.yml/badge.svg"></a>
   <a href="LICENSE"><img alt="Licence: AGPL-3.0-or-later" src="https://img.shields.io/badge/licence-AGPL--3.0--or--later-2dd4bf?style=flat-square"></a>
-  <a href="https://stalw.art"><img alt="Tested against Stalwart 0.16.19 and 0.15.5" src="https://img.shields.io/badge/Stalwart-0.16.19%20%7C%200.15.5-6366f1?style=flat-square"></a>
-  <img alt="JMAP: RFC 8620 and 8621" src="https://img.shields.io/badge/JMAP-RFC%208620%20%2F%208621-0891b2?style=flat-square">
-  <img alt="Node 20.10 or newer" src="https://img.shields.io/badge/node-%E2%89%A5%2020.10-3c873a?style=flat-square&logo=node.js&logoColor=white">
-  <img alt="TypeScript, strict" src="https://img.shields.io/badge/TypeScript-strict-3178c6?style=flat-square&logo=typescript&logoColor=white">
-  <img alt="No IMAP, no SMTP, no database" src="https://img.shields.io/badge/no%20IMAP%20%C2%B7%20no%20SMTP%20%C2%B7%20no%20database-ea580c?style=flat-square">
+  <a href="https://stalw.art" target="_blank" rel="noreferrer"><img alt="Tested against Stalwart 0.16.19 and 0.15.5" src="https://img.shields.io/badge/Stalwart-0.16.19%20%7C%200.15.5-6366f1?style=flat-square"></a>
+  <a href="https://linuxexpert.org" target="_blank" rel="noreferrer"><img alt="by LINUXexpert.org" src="https://img.shields.io/badge/by-LINUXexpert.org-0f766e?style=flat-square"></a>
 </p>
 
 # ihasmail


### PR DESCRIPTION
Down to three: the licence, the Stalwart generations this has actually been run against, and a **LINUXexpert.org** badge linking to the site. CI, JMAP, Node, TypeScript and no-IMAP are gone.

Both external links (Stalwart, LINUXexpert.org) carry `target="_blank"`.

**One thing to know: GitHub will ignore that.** Its README sanitiser strips `target` and rewrites `rel` to `nofollow` — checked against the Markdown API rather than assumed:

```
in:  <a href="https://linuxexpert.org" target="_blank" rel="noreferrer">
out: <a href="https://linuxexpert.org" rel="nofollow">
```

So on github.com those badges open in the same tab whatever the source says, and there is nothing in this repository that can change it. The attribute is kept because it does work wherever else the README is rendered — npm, docs sites, IDE previews — and costs nothing on GitHub.

All three badge URLs were fetched and rendered before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)