### PR TITLE
Let CI be started by hand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,14 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Lets CI be run by hand against any ref, including a specific commit.
+  # Without this there is no way to re-run a check that never started: a run
+  # GitHub queues and then orphans -- as it did to every run created during the
+  # Actions outage on 2026-08-26 -- can be neither rerun ("already running")
+  # nor cancelled ("already completed"), and the workflow has no other trigger
+  # to reach for. Useful too for putting a check on a commit that predates a CI
+  # change, without pushing an empty commit to move it.
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`ci.yml` triggers on a push to main and on pull requests, and nothing else. That left nothing to reach for when GitHub's Actions outage today orphaned the runs for `7a1e5ee` — the commit production is currently running.

Those two runs aren't slow, they're broken. GitHub accepted them, allocated **zero jobs**, and left them in a state its own API disagrees with itself about:

```
gh run rerun   →  "cannot be rerun; This workflow is already running"
gh run cancel  →  "Cannot cancel a workflow run that is completed"
gh api         →  status=queued, conclusion=null, jobs=0,
                  updated_at == created_at (never touched since 15:24:10)
```

Not rerunnable, not cancellable. Without a manual trigger the only remaining move would have been an empty commit pushed to main purely to move the ref — a junk commit, and against how changes land here.

`workflow_dispatch` fixes that permanently, and covers the ordinary case too: putting a check on a commit that predates a CI change, without inventing a commit to carry it.

One line of config plus the comment explaining why it's there. No job changes.

**After this merges**, CI can be run against any ref:

    gh workflow run ci.yml --ref main