### PR TITLE
Stop the deploy script rewriting itself mid-run

### DIFF
--- a/deploy.example.sh
+++ b/deploy.example.sh
@@ -49,6 +49,27 @@ IMAGE_REPO="${IHASMAIL_IMAGE:-ihasmail}"
 # How long to wait for the new container to report healthy, in seconds.
 HEALTH_TIMEOUT="${IHASMAIL_HEALTH_TIMEOUT:-30}"
 
+# --- run from a copy, if this script lives in the checkout it resets ---------
+# `git reset --hard` below rewrites the working tree, and this script may be
+# part of it. Bash does not read a script all at once -- it reads as it goes,
+# by byte offset -- so a file replaced underneath it makes the shell stop
+# wherever it had reached. Silently, and with exit status 0: a deploy that
+# stopped halfway would report success. Re-exec from a copy outside the tree so
+# the file being run cannot change while it runs.
+SELF="$(readlink -f "$0")"
+APP_REAL="$(readlink -f "$APP" 2>/dev/null || printf '%s' "$APP")"
+if [ -z "${IHASMAIL_REEXEC:-}" ] && [ "${SELF#"$APP_REAL"/}" != "$SELF" ]; then
+  COPY="$(mktemp "${TMPDIR:-/tmp}/ihasmail-deploy.XXXXXX")"
+  cat "$SELF" > "$COPY"
+  chmod +x "$COPY"
+  IHASMAIL_REEXEC=1 exec "$COPY" "$@"
+fi
+# The copy has served its purpose once we exit; the shell has finished reading
+# it by then.
+if [ -n "${IHASMAIL_REEXEC:-}" ]; then
+  trap 'rm -f "$SELF"' EXIT
+fi
+
 REF=""
 ASSUME_YES=0
 DRY_RUN=0


### PR DESCRIPTION
Found while installing #60 on the live host, before it ran there.

Moving the deploy script into the repo put it **inside the checkout it `git reset --hard`s**. Bash doesn't read a script all at once — it reads as it goes, by byte offset — so replacing the file underneath a running shell makes it stop wherever it had reached.

Silently, and with **exit status 0**. Demonstrated rather than assumed:

```bash
echo "line A"
cat > "$0" <<'NEW'
echo "REWRITTEN"
NEW
echo "line B"
```

prints `line A`, never reaches `line B`, and exits `0`.

In a deploy that means: build the image, stop before replacing the container, report success. The old container keeps serving while everything says the new one shipped.

It only bites when a deploy carries a change to the deploy script itself — rare enough to be baffling when it happens, and exactly the quiet-failure shape this project keeps paying for. The old host script lived *outside* the checkout, so it never had this problem; moving it in is what introduced it.

## The fix

Re-exec from a copy outside the tree before touching git, and remove the copy on exit. Running from outside the checkout skips the whole thing.

The trap is an `if` rather than `[ -n … ] && trap`. The latter rests on errexit ignoring a failed left operand of `&&` — it does (I checked), but a deploy script is a poor place to depend on knowing that.

## Testing

| case | result |
|---|---|
| script inside checkout, overwrites itself mid-run | every later line runs; temp copy removed |
| same without the guard | execution stops at the rewrite, exit 0 |
| script run from outside the checkout | no re-exec, unchanged behaviour |
| `--help` from both locations | exits 0 |

226 web + 75 server tests and typecheck unaffected.