### PR TITLE
Rework the sign-in footer

### DIFF
--- a/web/src/views/Login.tsx
+++ b/web/src/views/Login.tsx
@@ -96,12 +96,18 @@ export function LoginPage() {
         </button>
         <p className="foot">
           {/*
-            The version sits next to the source link on purpose: the AGPL's
-            offer is for the source of *this* build, and a version makes that
-            offer something a person can actually act on. It also means a bug
-            report names the build without anyone having to sign in to find it.
+            The version sits directly above the source link on purpose: the
+            AGPL's offer is for the source of *this* build, and naming the
+            build is what makes that offer something a person can act on. It
+            also means a bug report can name the build without anyone having
+            to sign in to find it.
+
+            One <p> with a break rather than two: .foot carries a 20px
+            margin-top, which a second paragraph would repeat as a gap.
           */}
-          ihasmail v{APP_VERSION} by <a href="https://ihasmail.org" target="_blank" rel="noopener noreferrer">ihasmail.org</a>
+          ihasmail v{APP_VERSION}
+          <br />
+          <a href="https://ihasmail.org" target="_blank" rel="noopener noreferrer">ihasmail.org</a>
           {" · "}
           <a href={sourceUrl} target="_blank" rel="noopener noreferrer">AGPL-3.0 source</a>
         </p>

--- a/web/src/views/Login.tsx
+++ b/web/src/views/Login.tsx
@@ -101,7 +101,7 @@ export function LoginPage() {
             offer something a person can actually act on. It also means a bug
             report names the build without anyone having to sign in to find it.
           */}
-          ihasmail v{APP_VERSION} by <a href="https://linuxexpert.org" target="_blank" rel="noopener noreferrer">linuxexpert.org</a>
+          ihasmail v{APP_VERSION} by <a href="https://ihasmail.org" target="_blank" rel="noopener noreferrer">ihasmail.org</a>
           {" · "}
           <a href={sourceUrl} target="_blank" rel="noopener noreferrer">AGPL-3.0 source</a>
         </p>


### PR DESCRIPTION
The build and where to find it were running together on one line. Now:

```
        ihasmail v2.16.61
  ihasmail.org · AGPL-3.0 source
```

Three changes:

- the link is **ihasmail.org**, href and label both — you're right that it isn't a lie, it's a LINUXexpert.org project site, so it says the same thing the old link did
- **"by" is gone.** It was doing attribution work the line no longer needs, and the README badge is where the credit properly lives
- the two links **drop to their own line**, leaving the name and version standing alone

One implementation note: it's a single `<p>` with a `<br />` rather than two paragraphs. `.foot` carries `margin-top: 20px`, which a second paragraph would repeat as a 20px gap under the sign-in button.

Verified `https://ihasmail.org` returns 200 before putting it in front of everyone who reaches the instance.

226 web tests, typecheck and build clean. The change is visible on the sign-in page after the next deploy.