### PR TITLE
Theme the dropdown a native select paints for itself

### DIFF
--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -626,7 +626,22 @@ img { max-width: 100%; }
 .composer-field .field-extra button { color: var(--fg-muted); padding: 2px 6px; border-radius: 4px; }
 .composer-field .field-extra button:hover { background: var(--bg-hover); color: var(--fg); }
 .composer-field input.plain { flex: 1; border: 0; background: transparent; outline: none; min-width: 80px; height: 30px; }
-.composer-field .from-select { flex: 1; border: 0; background: transparent; padding: 0; height: 30px; cursor: pointer; }
+.composer-field .from-select { flex: 1; border: 0; background: transparent; color: var(--fg); padding: 0; height: 30px; cursor: pointer; }
+
+/*
+ * A native <select>'s dropdown is painted by the browser from the element's own
+ * colours, not the page's. `.from-select` is deliberately transparent so it
+ * sits flush in the composer's From line -- which left its popup with no
+ * background of its own, so the browser drew a light one while the text kept
+ * the app's light foreground: light on light, unreadable in any dark theme.
+ *
+ * Styling `option` fixes the popup without giving the closed control a box.
+ * Scoped to every select rather than this one, because nothing else in the app
+ * styled options either -- the next transparent select would have arrived with
+ * the same bug.
+ */
+select option,
+select optgroup { background-color: var(--bg-elev); color: var(--fg); }
 .recipients { flex: 1; display: flex; flex-wrap: wrap; align-items: center; gap: 4px; min-width: 0; position: relative; }
 .recipients .chip { height: 24px; }
 .recipients input { flex: 1; min-width: 120px; border: 0; background: transparent; outline: none; height: 28px; }


### PR DESCRIPTION
Closes #70.

A native `<select>`'s popup is painted by the browser from **the element's own** colours, not the page's. `.from-select` is deliberately `background: transparent` so it sits flush in the composer's From line — which left its popup with no background of its own, so the browser drew a light one while the text kept the app's light foreground. Light on light, exactly as screenshotted.

## Fixed by styling `option`, not the control

That themes the popup without giving the closed select a box:

```css
.composer-field .from-select { … background: transparent; color: var(--fg); }
select option,
select optgroup { background-color: var(--bg-elev); color: var(--fg); }
```

Verified in the browser, computed rather than eyeballed:

| | before | after |
|---|---|---|
| select background | transparent | transparent — still flush |
| option background | *unset* → UA light | `#12303e` (`--bg-elev`) |
| option colour | light, inherited | `#eaf6f6` (`--fg`) |

That's **12.5:1** contrast where it was light-on-light. Chrome renders the popup in-page, so it's visible in a screenshot too — dark with readable text.

## Why it's scoped to every select

**Nothing in the app styled `option` anywhere.** So this wasn't one broken dropdown, it was the first one anyone happened to open in a dark theme. `.select` elsewhere gets away with it only because it sets an opaque `background` that the popup inherits. The next transparent select would have arrived with the same bug, so the rule covers all of them.

265 web + 77 server tests, typecheck and build clean. CSS only — no behaviour change.