### PR TITLE
Say so when the server refuses a subscribe

### DIFF
--- a/web/src/store/calendar.ts
+++ b/web/src/store/calendar.ts
@@ -3,6 +3,7 @@ import { CAP, client, setErrorMessage } from "@/jmap/client";
 import type { BusyPeriod, Calendar, CalendarEvent, GetResponse, Id, JSCalendarParticipant, JSCalendarRecurrenceRule, ParticipantIdentity, QueryResponse, SetResponse } from "@/jmap/types";
 import { toUTCDate, toLocalDateTime, zonedToDate, parseDuration, DAY_MS, browserTimeZone } from "@/lib/dates";
 import { settings } from "./settings";
+import { toast } from "@/ui/toast";
 import { useSession } from "./session";
 
 export interface EventInstance {
@@ -146,10 +147,15 @@ export const useCalendar = create<CalendarState>((set, get) => ({
   },
 
   async setSharedSubscribed(accountId, calendarId, subscribed) {
+    // See the note in the contacts store: subscribing writes to another
+    // account, so a refusal is an ordinary answer and arrives in `notUpdated`
+    // rather than as a thrown error.
     try {
-      await client.call("Calendar/set", { accountId, update: { [calendarId]: { isSubscribed: subscribed } } });
+      const res = await client.call<SetResponse>("Calendar/set", { accountId, update: { [calendarId]: { isSubscribed: subscribed } } });
+      const err = res.notUpdated?.[calendarId];
+      if (err) throw new Error(setErrorMessage(err));
     } catch (err) {
-      set({ error: (err as Error).message });
+      toast.error(`Could not ${subscribed ? "add" : "remove"} that calendar: ${(err as Error).message}`);
       return;
     }
     set((s) => ({

--- a/web/src/store/contacts.ts
+++ b/web/src/store/contacts.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { CAP, client, setErrorMessage } from "@/jmap/client";
 import type { AddressBook, ContactCard, EmailAddress, GetResponse, Id, Principal, QueryResponse, SetResponse } from "@/jmap/types";
 import { contactDisplayName, contactEmails, sortKey } from "@/lib/contacts";
+import { toast } from "@/ui/toast";
 import { useSession } from "./session";
 import { useMail } from "./mail";
 
@@ -166,10 +167,20 @@ export const useContacts = create<ContactsState>((set, get) => ({
   },
 
   async setBookSubscribed(accountId, bookId, subscribed) {
+    /*
+     * `notUpdated` matters more here than anywhere else this pattern is used.
+     * Subscribing is a write to somebody *else's* account, so it is the one
+     * call in the app that a perfectly healthy server is entitled to refuse --
+     * and a refusal arrives as a successful response carrying a per-object
+     * failure, not as a thrown error. Ignoring it made a refused subscribe look
+     * exactly like a button that does nothing.
+     */
     try {
-      await client.call("AddressBook/set", { accountId, update: { [bookId]: { isSubscribed: subscribed } } });
+      const res = await client.call<SetResponse>("AddressBook/set", { accountId, update: { [bookId]: { isSubscribed: subscribed } } });
+      const err = res.notUpdated?.[bookId];
+      if (err) throw new Error(setErrorMessage(err));
     } catch (err) {
-      set({ error: (err as Error).message });
+      toast.error(`Could not ${subscribed ? "add" : "remove"} that address book: ${(err as Error).message}`);
       return;
     }
     if (!subscribed && get().selection.accountId === accountId && get().selection.bookId === bookId) {


### PR DESCRIPTION
Adding a shared address book did nothing in Firefox and worked in Chrome. The button wasn't broken — **the refusal was invisible.**

Subscribing is the one call in the app that writes to somebody *else's* account, so it's the one a perfectly healthy server is entitled to say no to. And JMAP says no to a `/set` by answering **successfully**, with the object listed in `notUpdated`.

Neither subscribe method looked. The promise resolved, the code carried on, the re-read came back unchanged, and the row stayed exactly where it was with nothing said.

Every other `/set` in this codebase reads `notUpdated` and raises — `files.ts:313` and `:323`, for two. These two were written without it. That's the whole defect: not a wrong answer, an unread one.

Both now check it and surface what the server actually said.

### What this does not do

Fix the underlying refusal, because we don't know what it is yet. That's the point — whatever Stalwart is objecting to can now be read off the screen instead of inferred from which browser happened to be in front of you. My guess is that the two browsers are signed in as different accounts (owner vs sharee) and a read-only sharee cannot write `isSubscribed` on the owner's book, but that is a guess and the toast will replace it with the server's own words.

328 web and 77 server tests pass. `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)