### PR TITLE
Deploy immutably when asked to

### DIFF
--- a/deploy.example.sh
+++ b/deploy.example.sh
@@ -41,8 +41,23 @@ HOLD="${IHASMAIL_HOLD:-$APP/.deploy-hold}"
 # for a reverse proxy in front (see Caddyfile.example / nginx.example.conf).
 NAME="${IHASMAIL_NAME:-ihasmail}"
 BIND="${IHASMAIL_BIND:-127.0.0.1:8090}"
-# Named volume for /data (sessions).
+# Named volume for /data (sessions). Unused when running immutably.
 VOLUME="${IHASMAIL_VOLUME:-ihasmail-data}"
+# Run the container immutably: read-only root filesystem, no volume, sessions
+# held in memory only. See "Running immutably" in the README. The server is told
+# the same thing through IMMUTABLE=1 and checks it, so a half-applied switch --
+# the flag without the read-only filesystem, or a SESSION_FILE still pointing
+# somewhere -- refuses to start here instead of looking fine until the next
+# redeploy signs everyone out.
+#
+# The standing cost is that sessions do not outlive a deploy, because there is
+# nowhere left to keep them. Going back is this variable and nothing else:
+#
+#   IHASMAIL_IMMUTABLE=0 ./ihasmail-deploy.sh --yes
+#
+# The named volume is never touched either way, so whatever was in it when the
+# switch was thrown is still there to come back to.
+IMMUTABLE="${IHASMAIL_IMMUTABLE:-0}"
 # Image repository. Each build is tagged with its version as well, so an
 # earlier one can be run again without rebuilding it.
 IMAGE_REPO="${IHASMAIL_IMAGE:-ihasmail}"
@@ -194,10 +209,19 @@ docker build \
   -t "$IMAGE_REPO:current" \
   .
 
-echo "==> restarting container"
+RUN_ARGS=(-d --name "$NAME" --restart unless-stopped -p "$BIND:8080" --env-file "$ENVF")
+if [ "$IMMUTABLE" = "1" ]; then
+  # -e wins over --env-file, so this clears a SESSION_FILE set there or baked
+  # into the image, rather than needing the environment file edited to match.
+  RUN_ARGS+=(--read-only --tmpfs /tmp -e IMMUTABLE=1 -e SESSION_FILE=)
+  echo "==> restarting container -- immutable: read-only, no volume, sessions in memory"
+  echo "    (everyone signed in is signed out; IHASMAIL_IMMUTABLE=0 puts it back)"
+else
+  RUN_ARGS+=(-v "$VOLUME:/data")
+  echo "==> restarting container"
+fi
 docker rm -f "$NAME" >/dev/null 2>&1 || true
-docker run -d --name "$NAME" --restart unless-stopped \
-  -p "$BIND:8080" --env-file "$ENVF" -v "$VOLUME:/data" "$IMAGE_REPO:$TAG" >/dev/null
+docker run "${RUN_ARGS[@]}" "$IMAGE_REPO:$TAG" >/dev/null
 
 for _ in $(seq 1 "$HEALTH_TIMEOUT"); do
   if health=$(curl -sf "http://$BIND/api/health"); then


### PR DESCRIPTION
Follow-on to #117. That PR made an immutable container *possible*; this makes it **deployable**, which it was not — `ihasmail-deploy.sh` mounted the data volume unconditionally, so any redeploy would have quietly restored a mutable container underneath you.

`IHASMAIL_IMMUTABLE=1` switches the run line:

```
0 →  docker run -d --name ihasmail … --env-file … -v ihasmail-data:/data  ihasmail:TAG
1 →  docker run -d --name ihasmail … --env-file … --read-only --tmpfs /tmp -e IMMUTABLE=1 -e SESSION_FILE=  ihasmail:TAG
```

### Rollback is the same variable

```bash
IHASMAIL_IMMUTABLE=0 ./ihasmail-deploy.sh --yes
```

Verified that the `0` branch reproduces the current production run line exactly — `-v ihasmail-data:/data`, `readonly=false`, `restart=unless-stopped`. The named volume is never touched in either mode, so the sessions in it when the switch is thrown are still there to come back to.

### Why `-e` rather than editing the environment file

`.env.production` sets `SESSION_FILE`, and the image sets it too. Confirmed `-e` takes precedence over `--env-file`:

```
--env-file (SESSION_FILE=/data/sessions.json) + -e SESSION_FILE=  →  SESSION_FILE=[]
```

So the switch stays one variable in one place instead of two things that have to agree.

### The guard earns its keep here

`IMMUTABLE=1` reaches the server, which checks the claim rather than believing it. A half-applied switch — the flag without `--read-only`, or a `SESSION_FILE` that survived — fails at startup with a message naming the fix, instead of looking healthy until the next redeploy signs everyone out.

### Cost, stated plainly

Sessions do not outlive a deploy in this mode; there is nowhere to keep them. Everyone signs in again on each deploy. That goes away when OAuth moves the session into a token Stalwart issues and can revoke.

### Note on rollout

`deploy.example.sh` re-execs itself from `/tmp` before `git reset --hard`, so the *running* copy is always the previous one. The first deploy after this merges updates the checkout but still uses the old run line; the second picks up the new one. Two deploys to take effect, by design.