### PR TITLE
Lead with what makes it different

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,14 @@
 
 # ihasmail
 
-**A fast, friendly, Gmail-class webmail for [Stalwart Mail Server](https://stalw.art) — built on JMAP, from the ground up.**
+**Immutable webmail for [Stalwart Mail Server](https://stalw.art) — a container
+with nothing to persist, and a Gmail-class client on top of it.**
 
 Mail, calendars, contacts, files and filters in a responsive single-page app
 that works equally well on a desktop monitor and a phone. It talks only JMAP
 (plus Stalwart's blob/upload/EventSource endpoints) — no IMAP, no SMTP, no
-database.
+database, and with `IMMUTABLE=1` no writable filesystem either. Everything
+durable belongs to Stalwart; the container is disposable.
 
 | | |
 | --- | --- |
@@ -47,6 +49,7 @@ More, including the mobile layout, on [ihasmail.org](https://ihasmail.org/#scree
 - **Contacts** — JMAP Contacts / JSContact: address books, groups, full editor, vCard import/export
 - **Files** — JMAP FileNode: browse, upload, download, rename, move, delete
 - **Settings that follow the account**, not the browser — kept in a `settings.json` in the account's own JMAP Files, so ihasmail itself stays stateless
+- **Runs read-only** — one optional write path, and with it switched off the container needs no volume and no writable root. `IMMUTABLE=1` is checked at startup rather than trusted, so a half-applied switch refuses to boot instead of failing quietly. See [Running immutably](#running-immutably)
 - **Platform** — installable PWA, Web Push with ihasmail closed, `mailto:` handler, no credentials in the browser, strict CSP, SSRF-safe image proxy
 
 The long version is on [ihasmail.org](https://ihasmail.org/#features); how to


### PR DESCRIPTION
Repositions the README around immutability, now that it is true and shipped (#117–#120) and production runs that way.

**Before:** *"A fast, friendly, Gmail-class webmail for Stalwart Mail Server"* — describes the client, and is roughly what every webmail says.

**After:** *"Immutable webmail for Stalwart Mail Server — a container with nothing to persist, and a Gmail-class client on top of it."*

The Gmail comparison stays, one clause later. It is the fastest way to tell someone what the client feels like to use; it just isn't the differentiator. Immutability is — no other webmail for Stalwart can make the claim, and the competition mostly can't either: Roundcube and SOGo need a database, and Bulwark writes a setup wizard's config to a volume that is always read-write.

Also adds a **Runs read-only** bullet to *What's in it*, pointing at the existing `Running immutably` section rather than repeating it.

### Kept honest

The claim is scoped to what is actually true: `IMMUTABLE=1` is opt-in and off by default, and the README's `Running immutably` section already states the cost in plain terms — sessions live in memory, so every deploy signs everyone out. Nothing here implies the app is immutable in some inherent sense; it says the container can be, and what that costs.