### PR TITLE
Say where to report a code of conduct violation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-.
+**johnellisATlinuxDOTcom**.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
The Contributor Covenant ships its enforcement section with a placeholder for the contact address, and this copy never filled it in. The sentence whose entire job is to say where to report harassment currently reads:

> reported to the community leaders responsible for enforcement at
> .

So the document exists, counts toward GitHub's community profile score, and answers the question it was written to answer with a full stop. Anyone who needed it would have had to go looking elsewhere, at the moment they were least inclined to.

Uses the same obfuscated address as `SECURITY.md` and `CONTRIBUTING.md`, so there is one contact for the project rather than a second to keep in sync.

Found while porting this file to `cairnobs`, which is about to go public and would otherwise have inherited the same gap.