### PR TITLE
Link the project site from inside the app

### DIFF
--- a/web/src/views/AppShell.tsx
+++ b/web/src/views/AppShell.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type ReactNode } from "react";
 import { Link, useLocation } from "wouter";
-import { BookOpen, Calendar, ChevronsUpDown, FolderOpen, HelpCircle, LogOut, Mail, Menu as MenuIcon, Moon, PenSquare, Plus, RefreshCw, Settings, Sun, Upload, Users } from "lucide-react";
+import { BookOpen, Calendar, ChevronsUpDown, FolderOpen, Globe, HelpCircle, LogOut, Mail, Menu as MenuIcon, Moon, PenSquare, Plus, RefreshCw, Settings, Sun, Upload, Users } from "lucide-react";
 import { useSession } from "@/store/session";
 import { toggleTarget, useEffectiveTheme, useSettings } from "@/store/settings";
 import { useMail } from "@/store/mail";
@@ -102,6 +102,10 @@ export function AppShell({ children }: { children: ReactNode }) {
             </div>
             <MenuSep />
             <MenuItem icon={<BookOpen size={16} />} label="Documentation" href="https://docs.ihasmail.org" external />
+            {/* The project site. It is linked from the login screen footer, which
+                is a page a signed-in user never sees again -- so from inside the
+                app there was no way back to it. */}
+            <MenuItem icon={<Globe size={16} />} label="About ihasmail" href="https://ihasmail.org" external />
             <MenuItem icon={<Settings size={16} />} label="Settings" onClick={() => navigate("/settings")} />
             <MenuItem icon={<RefreshCw size={16} />} label="Refresh" onClick={() => window.location.reload()} />
             <MenuItem icon={<LogOut size={16} />} label="Sign out" onClick={() => void logout()} />


### PR DESCRIPTION
`ihasmail.org` was linked only from the **login screen footer** — a page a
signed-in user sees once and never again. From inside the app there was no
route back to the project site: Documentation goes to `docs.ihasmail.org`, and
that was the whole of it.

"About ihasmail" now sits directly under Documentation in the account menu,
which is where someone wondering what this thing is would actually look. Same
`MenuItem` / `external` treatment as its neighbour, so it opens in a new tab
with the same handling.

`tsc --noEmit` clean.
