### PR TITLE
Change the copyright holder to Coffey Labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="LICENSE"><img alt="Licence: AGPL-3.0-or-later" src="https://img.shields.io/badge/licence-AGPL--3.0--or--later-2dd4bf?style=flat-square"></a>
   <a href="https://stalw.art" target="_blank" rel="noreferrer"><img alt="Requires Stalwart 0.16 or newer; tested against 0.16.19" src="https://img.shields.io/badge/Stalwart-0.16.19-6366f1?style=flat-square"></a>
   <a href="https://docs.ihasmail.org" target="_blank" rel="noreferrer"><img alt="Documentation: docs.ihasmail.org" src="https://img.shields.io/badge/docs-docs.ihasmail.org-0ea5e9?style=flat-square"></a>
-  <a href="https://linuxexpert.org" target="_blank" rel="noreferrer"><img alt="by LINUXexpert.org" src="https://img.shields.io/badge/by-LINUXexpert.org-0f766e?style=flat-square"></a>
+  <a href="https://coffeylabs.org" target="_blank" rel="noreferrer"><img alt="by Coffey Labs" src="https://img.shields.io/badge/by-Coffey%20Labs-0f766e?style=flat-square"></a>
 </p>
 
 # ihasmail
@@ -200,7 +200,7 @@ container, waits for healthy, then prunes all but the newest
 
 ## License
 
-Copyright (C) 2026 LINUXexpert.org — AGPL-3.0-or-later. See
+Copyright (C) 2026 Coffey Labs — AGPL-3.0-or-later. See
 [LICENSE](LICENSE).
 
 ihasmail was relicensed from GPL-3.0 to AGPL-3.0 on 2026-08-25: webmail is


### PR DESCRIPTION
Fourth of five. Two lines.

```
- Copyright (C) 2026 LINUXexpert.org — AGPL-3.0-or-later.
+ Copyright (C) 2026 Coffey Labs — AGPL-3.0-or-later.
```

## The badge mattered as much as the licence line

The header carried `by LINUXexpert.org`, linking to a site that **is now
retired** — it 301s its articles to jcoffey.dev and answers 410 for everything
else. So the attribution badge on this project pointed somewhere that no longer
claims the work. It now reads `by Coffey Labs` and points at coffeylabs.org.
Both the badge image and the destination were checked and return 200.

## What stays

Every other `LINUXexpert-org` here is a `github.com` URL — the source link baked
into `.env.example`, `docker-compose.yml`, `web/src/lib/source.ts` and
`server/src/config.ts`, plus issue and release links in the docs. Six of them,
unchanged. **The AGPL source offer in the running app depends on that URL
resolving**, so rewriting it would be a licence-compliance problem rather than a
licence update.

`LICENSE` untouched — its only copyright is the FSF's on the AGPL text itself.
