### PR TITLE
Stalwart has not reached 1.0 yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,9 @@ to look wrong: a version with no `+pr` or `+g` means whoever built the image did
 not pass one.
 
 The version says nothing about Stalwart, deliberately. It used to: `2.16.x` had
-`16` for the 0.16 generation it targeted, which left nowhere to go when Stalwart
-reached 1.0 — `2.1` sorts *below* the `2.16` already deployed, so every image and
-About screen would have read as a downgrade. Which Stalwart a build needs is
+`16` for the 0.16 generation it targeted, which leaves nowhere to go once
+Stalwart reaches 1.0 — `2.1` sorts *below* the `2.16` already deployed, so every
+image and About screen would read as a downgrade. Which Stalwart a build needs is
 stated where it can be precise, in the badge at the top of this file and in
 [KNOWN-ISSUES.md](KNOWN-ISSUES.md), rather than compressed into one digit.
 

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -5,12 +5,12 @@
  *   +pr129     the pull request it arrived through
  *
  * The date leads because ihasmail's version used to be `2.16.<pr>`, where `16`
- * was the Stalwart generation it targeted -- and Stalwart 1.0 leaves that with
- * nowhere to go. `2.1` would have sorted *below* the `2.16` already deployed,
- * so every image and About screen would have read as a downgrade. Tying our
+ * was the Stalwart generation it targeted -- and Stalwart 1.0 will leave that
+ * with nowhere to go. `2.1` would sort *below* the `2.16` already deployed, so
+ * every image and About screen would read as a downgrade. Tying our
  * numbering to somebody else's was the mistake; which Stalwart a build needs is
  * said properly in the README badge and KNOWN-ISSUES, where it can be precise
- * ("0.16 or newer; tested against 0.16.19") rather than one digit.
+ * ("0.16 or newer; tested against 0.16.20") rather than one digit.
  *
  * The pull request moved into build metadata, after the `+`, because it is
  * provenance rather than a position in a sequence: at a hundred merges a week


### PR DESCRIPTION
Matches the same fix on the site ([ihasmail.org#59](https://github.com/Coffey-Labs/ihasmail.org/pull/59)) and in the install docs ([ihasmail.org#60](https://github.com/Coffey-Labs/ihasmail.org/pull/60)).

`scripts/version.mjs` and `README.md` both explained the move off `2.16.x` in the past tense — "Stalwart 1.0 **leaves** that with nowhere to go", "which **left** nowhere to go when Stalwart **reached** 1.0". Stalwart has not got there. The scheme was dropped over where `2.16.x` *would* end up, not where it ended up, so the surrounding conditionals collapse from "would have sorted / would have read" to "would sort / would read".

Also: the comment quotes the README badge as "0.16 or newer; tested against 0.16.19". The badge says 0.16.20 as of #134.

Comments and prose only — no behaviour change. `node scripts/version.mjs` still resolves correctly.