### PR TITLE
Deploy immutably by default

### DIFF
--- a/deploy.example.sh
+++ b/deploy.example.sh
@@ -54,6 +54,13 @@ VOLUME="${IHASMAIL_VOLUME:-ihasmail-data}"
 # somewhere -- refuses to start here instead of looking fine until the next
 # redeploy signs everyone out.
 #
+# It defaults to on, and the reason is what happens when it does not. Forgetting
+# the variable used to hand back a writable container with a volume mounted --
+# quietly, and then report healthy. Nothing in the output said the immutability
+# had gone; `docker inspect` was the only place it showed. So the safe posture
+# is what you get by default, and giving it up is the half that has to be
+# deliberate, which is the way round these two should always have been.
+#
 # The standing cost is that sessions do not outlive a deploy, because there is
 # nowhere left to keep them. Going back is this variable and nothing else:
 #
@@ -61,7 +68,7 @@ VOLUME="${IHASMAIL_VOLUME:-ihasmail-data}"
 #
 # The named volume is never touched either way, so whatever was in it when the
 # switch was thrown is still there to come back to.
-IMMUTABLE="${IHASMAIL_IMMUTABLE:-0}"
+IMMUTABLE="${IHASMAIL_IMMUTABLE:-1}"
 # Image repository. Each build is tagged with its version as well, so an
 # earlier one can be run again without rebuilding it.
 IMAGE_REPO="${IHASMAIL_IMAGE:-ihasmail}"


### PR DESCRIPTION
`IHASMAIL_IMMUTABLE` defaulted to `0`, and `.env.production` doesn't set it either. So a plain `./deploy.sh origin/main --yes` handed back a **writable container with a `/data` volume mounted** — quietly, and then reported healthy.

Nothing in the deploy output said the immutability had gone. `docker inspect` was the only place it showed, and only if you thought to look:

```
ReadonlyRootfs=false  Mounts=1
```

That is the wrong way round for the posture the project leads with. The safe one is now the default, and giving it up is the half that has to be deliberate:

```
IHASMAIL_IMMUTABLE=0 ./ihasmail-deploy.sh --yes
```

Found by deploying prod today. The running container had `IMMUTABLE=1` and a read-only root, and reproducing that state took passing the variable by hand — because the script's own default would have taken it away.

No behaviour change for anyone already passing `IHASMAIL_IMMUTABLE=1`, and the named volume is still never touched either way, so an instance that opts back out finds whatever was in it.

One line of code; the rest is the comment explaining which way round the two options should sit and why.