### PR TITLE
Put "compose as new" where a thumb can find it

### DIFF
--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -642,7 +642,10 @@ a.menu-item:hover { color: var(--fg); }
 .vcard-card { margin: 0 16px 12px; padding: 12px 16px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg-sunken); display: flex; align-items: center; gap: 12px; }
 .unsubscribe-row { margin: 0 16px 8px; font-size: .88em; color: var(--fg-muted); display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 .reply-box { margin: 8px 16px 24px; }
-.reply-box .reply-prompt { display: flex; gap: 8px; align-items: center; padding: 12px; border: 1px solid var(--border); border-radius: var(--radius); color: var(--fg-muted); }
+/* Wraps, because it does not fit. Three labelled buttons and an overflow need
+   about 390px of it, which a 430px phone has and a 360px one does not -- and it
+   was already over the line on the smaller ones before the overflow was added. */
+.reply-box .reply-prompt { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; padding: 12px; border: 1px solid var(--border); border-radius: var(--radius); color: var(--fg-muted); }
 .reply-box .reply-prompt button { display: inline-flex; align-items: center; gap: 6px; padding: 8px 14px; border-radius: 999px; border: 1px solid var(--border-strong); color: var(--fg); font-weight: 500; }
 .reply-box .reply-prompt button:hover { background: var(--bg-hover); }
 .no-thread { height: 100%; display: flex; align-items: center; justify-content: center; flex-direction: column; gap: 8px; color: var(--fg-muted); }
@@ -1214,6 +1217,9 @@ button.dp-open:disabled { cursor: default; opacity: .5; }
 .dp-time:hover { background: var(--bg-hover); }
 .dp-time.selected { background: var(--accent); color: var(--accent-fg); }
 @media (max-width: 480px) {
+  /* The spacer would take the whole of the first line and push the overflow
+     onto a line of its own; packed together they wrap as a group instead. */
+  .reply-box .reply-prompt .spacer { display: none; }
   .dp-datetime { flex-wrap: wrap; }
   .dp-datetime .dp-time-field { flex: 1 1 100%; }
   .dp-split { flex-direction: column; }

--- a/web/src/views/mail/ThreadView.tsx
+++ b/web/src/views/mail/ThreadView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { AlertOctagon, Archive, ArrowLeft, ChevronDown, ChevronUp, FolderInput, Forward, Mail, MailOpen, MoreVertical, Printer, Reply, ReplyAll, ShieldCheck, Star, Tag, Trash2, Download } from "lucide-react";
+import { AlertOctagon, Archive, ArrowLeft, ChevronDown, ChevronUp, FolderInput, Forward, Mail, MailOpen, MailPlus, MoreVertical, Printer, Reply, ReplyAll, ShieldCheck, Star, Tag, Trash2, Download } from "lucide-react";
 import { useMail } from "@/store/mail";
 import { useSettings } from "@/store/settings";
 import { useCompose } from "@/store/compose";
@@ -42,6 +42,8 @@ export function ThreadView({ threadId, mailboxId, onBack, actions, onNavigate, h
   const [allExpanded, setAllExpanded] = useState(false);
   const [labelAnchor, setLabelAnchor] = useState<{ x: number; y: number } | null>(null);
   const moreMenu = useMenu();
+  /** The overflow on the reply strip, which is the only per-message menu a phone offers easily. */
+  const replyMore = useMenu();
   const scrollRef = useRef<HTMLDivElement>(null);
   const markTimer = useRef<number | null>(null);
   const isTouch = useIsTouch();
@@ -289,6 +291,19 @@ export function ThreadView({ threadId, mailboxId, onBack, actions, onNavigate, h
               <button onClick={() => void reply(last, "reply")}><Reply size={16} />  {t("Reply")}</button>
               <button onClick={() => void reply(last, "replyAll")}><ReplyAll size={16} />  {t("Reply all")}</button>
               <button onClick={() => void reply(last, "forward")}><Forward size={16} />  {t("Forward")}</button>
+              {/*
+                On a phone this strip is where a thumb goes, and the per-message
+                menu at the top of a card is not somewhere anybody looks for
+                "send this again" -- which is how compose-as-new came to be
+                reported missing on mobile when it was there all along (#181).
+                A fourth full button does not fit at 500px; this does, and it
+                spells the action out once opened.
+              */}
+              <span className="spacer" />
+              <button className="icon-btn" onClick={replyMore.open} aria-label={t("More ways to send this")}><MoreVertical size={18} /></button>
+              <Popover anchor={replyMore.anchor} onClose={replyMore.close} align="end" width={220}>
+                <MenuItem icon={<MailPlus size={16} />} label={t("Compose as new")} onClick={() => void useCompose.getState().composeAsNew(last)} />
+              </Popover>
             </div>
           </div>
         )}


### PR DESCRIPTION
Closes #181.

## What was actually wrong

It was never absent on a phone — I checked in a mobile viewport, and it's there in the per-message ⋮ menu, fourth item, right after Forward. But **that is not where anybody looks.** On a phone you act on a thread from the strip at the bottom (Reply / Reply all / Forward), and what isn't in that strip is, for practical purposes, not there.

So the strip gets an overflow of its own with compose-as-new in it. A fourth *labelled* button doesn't fit; a ⋮ does, and it spells the action out once opened. It's present at every width, not just mobile — the per-message menu keeps its copy.

## A layout bug found while placing it

Measuring the strip to see what would fit turned up something worth fixing on its own. The three labelled buttons come to **391px** of content, which fits a 430px phone and does **not** fit 390, 360 or 320. That was already true before today — Reply / Reply all / Forward alone need ~347px, over the line on a 360px phone — and the strip simply overflowed horizontally.

It now wraps, and the spacer that would otherwise take the whole first line and push the overflow onto a line of its own is dropped below 480px, so the buttons wrap as a group.

## Verification

`npm run typecheck`, `npm test` (564 pass) and `npm run build` green; no new tests — this is placement and layout, and the behaviour behind it is already covered by the `compose-as-new` store tests.

In the browser against `dev:mock`:

- confirmed first, at a mobile breakpoint, that compose-as-new **was** in the per-message ⋮ and **was not** in the bottom strip — i.e. what the report is actually about
- the strip now reads Reply / Reply all / Forward / ⋮, and the menu opens with **Compose as new**
- measured the strip's content at 391px and confirmed it clears 430px but not 390/360/320
- with the container narrowed to each of 430 / 390 / 360 / 320, the strip **wraps instead of overflowing** at every one

One caveat on that last point: the window manager stopped honouring resize requests partway through, so the wrap was verified by narrowing the container rather than the viewport — which means the ≤480px rule that hides the spacer was *not* exercised, and the measurement above is the pessimistic case with the spacer still flexing. It doesn't overflow even so.

## Also true, and not fixed here

On a touchscreen there is no per-row context menu in the message list at all — holding a row starts selection instead — so Reply, Forward and compose-as-new are all unreachable from the list on a phone. That predates this feature and is a bigger question about what a long-press should do; happy to open an issue for it if you want it looked at.