### PR TITLE
Print on white, and start on page one

### DIFF
--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -1172,10 +1172,69 @@ select optgroup { background-color: var(--bg-elev); color: var(--fg); }
   .msg-row:hover .msg-meta .msg-date { display: inline; }
   .nav-item .nav-more, .cal-list-item .nav-more { opacity: 1; }
 }
+/*
+ * Print.
+ *
+ * Paper has no theme. Whatever palette is on screen, the tokens are pinned to
+ * a light, unpainted set here -- backgrounds white rather than the light
+ * theme's greys, since a printer would otherwise lay ink over the whole sheet.
+ * Doing it on the tokens rather than per rule is what reaches the message
+ * body: it renders in a shadow root this stylesheet cannot select into, and
+ * follows the app theme through inherited custom properties (see
+ * EMAIL_BASE_CSS in lib/html.ts). Mail that brings colours of its own is left
+ * alone -- it is not themed in the first place.
+ *
+ * `!important` rather than a longer selector: the dark palettes sit on
+ * :root[data-theme] and :root[data-palette][data-accent], and out-specifying
+ * every one of them is a chain that the next palette breaks.
+ */
 @media print {
-  .topbar, .sidebar, .mail-list-pane, .thread-toolbar, .composer-dock, .toast-host, .mobile-tabbar, .fab, .reply-box, .thread-actions, .quote-toggle { display: none !important; }
+  :root {
+    --bg: #fff !important;
+    --bg-elev: #fff !important;
+    --bg-sunken: #fff !important;
+    --bg-hover: transparent !important;
+    --bg-active: transparent !important;
+    --unread-bg: #fff !important;
+    --read-bg: #fff !important;
+    --selected-bg: transparent !important;
+    --fg: #000 !important;
+    --fg-muted: #3a3a3a !important;
+    --fg-faint: #5a5a5a !important;
+    --border: #ccc !important;
+    --border-strong: #999 !important;
+    --accent: #0f766e !important;
+    --accent-fg: #fff !important;
+    --accent-soft: transparent !important;
+    --accent-soft-fg: #0b5750 !important;
+    --danger: #b91c1c !important;
+    --danger-soft: transparent !important;
+    --warn: #92400e !important;
+    --warn-soft: transparent !important;
+    --success: #15803d !important;
+    --success-soft: transparent !important;
+    --link: #0e7490 !important;
+    --star: #444 !important;
+    --q1: #1d4ed8 !important;
+    --q2: #15803d !important;
+    --q3: #7e22ce !important;
+    --shadow-1: none !important;
+    --shadow-2: none !important;
+    --shadow-3: none !important;
+    color-scheme: light !important;
+  }
+  .topbar, .sidebar, .mail-list-pane, .splitter, .thread-toolbar, .composer-dock, .toast-host, .mobile-tabbar, .fab, .reply-box, .thread-actions, .quote-toggle { display: none !important; }
+  .message-head .meta .icon-btn, .message-head .who .to button { display: none !important; }
   .app, .app-body, .main, .mail-layout, .mail-reading-pane, .thread-view, .thread-scroll { display: block !important; height: auto !important; overflow: visible !important; grid-template-columns: 1fr !important; border: 0 !important; }
-  .message { break-inside: avoid; border: 1px solid #ccc; }
+  /*
+   * `break-inside: avoid` on the whole card is what put the first message on
+   * page two: a message longer than a sheet cannot honour it, and Chrome
+   * answers by moving the card to a fresh page and breaking it there anyway --
+   * leaving page one holding nothing but the subject. Only the header is
+   * indivisible now, and it is kept with the body that follows it.
+   */
+  .message { break-inside: auto; border: 1px solid var(--border); }
+  .message-head { break-inside: avoid; break-after: avoid; }
   .print-only { display: block; }
   body { background: #fff; color: #000; }
 }


### PR DESCRIPTION
Two print bugs, both in the `@media print` block of `web/src/styles/app.css`.

**Printing carried the screen theme.** A dark reader printed a dark sheet. `body { background: #fff }` was not enough: every card, header and detail row paints from `--bg-elev` / `--bg-sunken` / `--fg`, and the message body renders in a shadow root that no rule in this stylesheet can select into — it follows the app palette through inherited custom properties (`EMAIL_BASE_CSS` in `web/src/lib/html.ts`). Pinning the tokens themselves to a light set is what reaches it. Backgrounds go white rather than the light theme greys, so a printer is not asked to ink the whole sheet. Mail that brings colours of its own is untouched — it was never themed.

`!important` rather than a longer selector: the dark palettes live on `:root[data-theme]` and `:root[data-palette][data-accent]`, and out-specifying all of them is a chain the next palette breaks.

**Page one was blank apart from the subject.** `break-inside: avoid` on `.message` cannot be honoured by a message taller than a sheet; Chrome answers by moving the card to a fresh page and breaking it there anyway. Only `.message-head` is indivisible now, and `break-after: avoid` keeps it with the body it introduces.

Also hidden for print: the pane splitter, and the star / details buttons in the message header — controls that print as ink and do nothing on paper.

## Verified

Headless Chrome print-to-PDF of the reading pane markup against this stylesheet, `data-theme="dark"`, message body in a real shadow root with the themed class.

| | before | after |
|---|---|---|
| pages | 3 | 2 |
| page 1 | subject only, on a near-black sheet | subject + sender + body, white |

Re-rendered with the dark theme off as well: still 2 pages, content from page 1.