### PR TITLE
Gather the privacy settings into a section of their own

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist/
 server/data/
 .vite/
 coverage/
+
+# Worktrees used by parallel agents; never part of a commit.
+.claude/worktrees/

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -654,7 +654,8 @@ not reach another that already has ihasmail open until it signs in again.
 
 | Section | Holds |
 | --- | --- |
-| **General** | Reading pane, mark-as-read delay, auto-advance, remote images, conversation view, snippets, avatars, confirm-before-delete; compose format, undo-send window, quoting, signature placement, attachment reminder, read-receipt policy, spell check; time zone, week start, language & region, date format, time format; `mailto:` handler; export / import / reset |
+| **General** | Reading pane, mark-as-read delay, auto-advance, conversation view, snippets, avatars; compose format, quoting, signature placement, spell check; time zone, week start, language & region, date format, time format; `mailto:` handler; export / import / reset |
+| **Privacy & safety** | Remote images and the senders trusted with them, read receipts asked for and answered, undo-send window, attachment reminder, confirm-before-delete |
 | **Appearance** | Theme, accent colour, density, font size, sidebar, swipe actions, interface language |
 | **Identities & signatures** | Addresses, names, Reply-To, HTML signatures, the default, and which to hide from the picker |
 | **Filters & rules** | The visual builder and raw Sieve editor |
@@ -667,6 +668,20 @@ not reach another that already has ihasmail open until it signs in again.
 | **Security & sessions** | Password, two-factor state, app passwords, active webmail sessions |
 | **Keyboard shortcuts** | The full list, grouped |
 | **About** | Version, source URL, server, and the capabilities it advertises |
+
+**Privacy & safety is separate from Security & sessions**, and the line
+between them is worth stating because two similar words in one nav is how a
+menu becomes something people hunt through. Security & sessions is credentials
+and access: password, two-factor state, app passwords, live sessions. Privacy &
+safety is how the app behaves towards the reader and towards senders: what
+loads, what leaks, and what asks before it happens. These had been spread
+through General, which had grown five unrelated headings — remote images filed
+under "Reading", the read-receipt policy under "Composing", the undo-send window
+beside the default message format.
+
+The senders trusted with remote images are listed there and can be withdrawn
+one at a time. Previously a sender was added from a message and could only be
+removed by finding another message from the same sender.
 
 Settings **export** to a JSON file and **import** back, and reset to defaults.
 

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -1376,3 +1376,6 @@ button.dp-open:disabled { cursor: default; opacity: .5; }
 .composer-field label .link-btn { background: none; border: 0; padding: 0; font: inherit; color: inherit; cursor: pointer; text-decoration: underline; text-decoration-style: dotted; text-underline-offset: 3px; }
 .composer-field label .link-btn:hover { color: var(--accent); }
 .composer-field label .link-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 3px; }
+
+/* The senders whose remote images load without asking, in Privacy & safety. */
+.trusted-senders { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 6px; }

--- a/web/src/views/settings/GeneralSettings.tsx
+++ b/web/src/views/settings/GeneralSettings.tsx
@@ -1,4 +1,4 @@
-import { useSettings, type ReadReceiptPolicy } from "@/store/settings";
+import { useSettings } from "@/store/settings";
 import { Switch } from "@/ui/misc";
 import { browserTimeZone, listTimeZones } from "@/lib/dates";
 import { toast } from "@/ui/toast";
@@ -47,7 +47,7 @@ export function GeneralSettings() {
   return (
     <div>
       <h1>{t("General")}</h1>
-      <p className="lead">{t("Reading, sending and list behaviour. Settings are stored in this browser.")}</p>
+      <p className="lead">{t("Reading, sending, and how dates and times are shown. What reaches a sender lives in Privacy & safety.")}</p>
 
       <h2>{t("Reading")}</h2>
       <div className="field-row">
@@ -76,19 +76,10 @@ export function GeneralSettings() {
             <option value="newer">{t("Open the previous (newer) conversation")}</option>
           </select>
         </div>
-        <div className="field">
-          <label>{t("Remote images")}</label>
-          <select className="select" value={s.imagePolicy} onChange={(e) => update({ imagePolicy: e.target.value as typeof s.imagePolicy })}>
-            <option value="ask">{t("Ask before showing (recommended)")}</option>
-            <option value="contacts">{t("Show automatically from my contacts")}</option>
-            <option value="always">{t("Always show")}</option>
-          </select>
-        </div>
       </div>
       <Switch checked={s.conversationMode} onChange={(v) => update({ conversationMode: v })} label={t("Conversation view")} hint={t("Group messages from the same thread together.")} />
       <Switch checked={s.showPreview} onChange={(v) => update({ showPreview: v })} label={t("Show message snippets")} hint={t("Preview the first line of each message in the list.")} />
       <Switch checked={s.showAvatars} onChange={(v) => update({ showAvatars: v })} label={t("Show sender avatars")} />
-      <Switch checked={s.confirmDelete} onChange={(v) => update({ confirmDelete: v })} label={t("Confirm before deleting")} />
 
       <h2>{t("Composing")}</h2>
       <div className="field-row">
@@ -99,32 +90,9 @@ export function GeneralSettings() {
             <option value="text">{t("Plain text")}</option>
           </select>
         </div>
-        <div className="field">
-          <label>{t("Undo send window")}</label>
-          <select className="select" value={String(s.undoSendSeconds)} onChange={(e) => update({ undoSendSeconds: Number(e.target.value) })}>
-            <option value="0">{t("Off")}</option>
-            <option value="5">{t("5 seconds")}</option>
-            <option value="8">{t("8 seconds")}</option>
-            <option value="15">{t("15 seconds")}</option>
-            <option value="30">{t("30 seconds")}</option>
-          </select>
-        </div>
       </div>
       <Switch checked={s.includeQuote} onChange={(v) => update({ includeQuote: v })} label={t("Quote original message in replies")} />
       <Switch checked={s.signatureAboveQuote} onChange={(v) => update({ signatureAboveQuote: v })} label={t("Place signature above quoted text")} />
-      <Switch checked={s.attachmentReminder} onChange={(v) => update({ attachmentReminder: v })} label={t("Attachment reminder")} hint={t("Warn when the message mentions an attachment but none is attached.")} />
-      <Switch checked={s.requestReadReceipt} onChange={(v) => update({ requestReadReceipt: v })} label={t("Always request read receipts")} />
-      <div className="field">
-        <label>{t("When someone requests a read receipt")}</label>
-        <select className="select" value={s.readReceiptPolicy} onChange={(e) => update({ readReceiptPolicy: e.target.value as ReadReceiptPolicy })}>
-          <option value="ask">{t("Ask me on each message")}</option>
-          <option value="never">{t("Never send one")}</option>
-        </select>
-        <p className="hint">
-          
-          {t("A receipt tells whoever asked that this address is live and when the message was read, and the sender chooses where it goes — so there is no automatic option. Bulk mail, mailing lists and anything marked auto-submitted are never offered one at all.")}
-        </p>
-      </div>
       <Switch checked={s.spellcheck} onChange={(v) => update({ spellcheck: v })} label={t("Spell check while typing")} />
 
       <h2>{t("Locale")}</h2>

--- a/web/src/views/settings/PrivacySettings.tsx
+++ b/web/src/views/settings/PrivacySettings.tsx
@@ -1,0 +1,93 @@
+import { useSettings, type ReadReceiptPolicy } from "@/store/settings";
+import { Switch } from "@/ui/misc";
+import { X } from "lucide-react";
+import { t } from "@/lib/i18n";
+
+/**
+ * Everything about what reaches a sender, and what asks before it happens.
+ *
+ * These settings were spread through General, which had grown into five
+ * unrelated headings -- remote images filed under "Reading", the read-receipt
+ * policy under "Composing", the undo-send window beside the default message
+ * format. They are the same kind of decision and they belong together, and
+ * gathering them leaves General smaller as well.
+ *
+ * The boundary against **Security & sessions** is worth keeping sharp, since
+ * two similar words next to each other in a nav is how a menu becomes
+ * something people hunt through: that section is credentials and access --
+ * password, two-factor, app passwords, live sessions. This one is how the app
+ * behaves towards the reader and towards senders.
+ */
+export function PrivacySettings() {
+  const s = useSettings((st) => st.settings);
+  const update = useSettings((st) => st.update);
+  const trusted = s.trustedImageSenders;
+
+  return (
+    <div>
+      <h1>{t("Privacy & safety")}</h1>
+      <p className="lead">{t("What reaches a sender, and what asks before it happens.")}</p>
+
+      <h2>{t("Remote content")}</h2>
+      <div className="field">
+        <label>{t("Remote images")}</label>
+        <select className="select" value={s.imagePolicy} onChange={(e) => update({ imagePolicy: e.target.value as typeof s.imagePolicy })}>
+          <option value="ask">{t("Ask before showing (recommended)")}</option>
+          <option value="contacts">{t("Show automatically from my contacts")}</option>
+          <option value="always">{t("Always show")}</option>
+        </select>
+        <p className="hint">
+          {t("An image loaded from a sender's server tells them the message was opened, when, and from roughly where. Approved images are fetched by ihasmail's own server rather than the browser, so the sender learns none of those.")}
+        </p>
+      </div>
+      {trusted.length > 0 && (
+        <div className="field">
+          <label>{t("Always showing images from")}</label>
+          <div className="trusted-senders">
+            {trusted.map((addr) => (
+              <span key={addr} className="chip">
+                <span className="notranslate" translate="no">{addr}</span>
+                <button
+                  className="chip-x"
+                  aria-label={t("Stop trusting {address}", { address: addr })}
+                  onClick={() => update({ trustedImageSenders: trusted.filter((x) => x !== addr) })}
+                >
+                  <X size={13} />
+                </button>
+              </span>
+            ))}
+          </div>
+          <p className="hint">{t("Added from a message, and removable here — previously the only way to undo one was to find another message from the same sender.")}</p>
+        </div>
+      )}
+
+      <h2>{t("Read receipts")}</h2>
+      <Switch checked={s.requestReadReceipt} onChange={(v) => update({ requestReadReceipt: v })} label={t("Always request read receipts")} />
+      <div className="field">
+        <label>{t("When someone requests a read receipt")}</label>
+        <select className="select" value={s.readReceiptPolicy} onChange={(e) => update({ readReceiptPolicy: e.target.value as ReadReceiptPolicy })}>
+          <option value="ask">{t("Ask me on each message")}</option>
+          <option value="never">{t("Never send one")}</option>
+        </select>
+        <p className="hint">
+          {t("A receipt tells whoever asked that this address is live and when the message was read, and the sender chooses where it goes — so there is no automatic option. Bulk mail, mailing lists and anything marked auto-submitted are never offered one at all.")}
+        </p>
+      </div>
+
+      <h2>{t("Before it happens")}</h2>
+      <div className="field">
+        <label>{t("Undo send window")}</label>
+        <select className="select" value={String(s.undoSendSeconds)} onChange={(e) => update({ undoSendSeconds: Number(e.target.value) })}>
+          <option value="0">{t("Off")}</option>
+          <option value="5">{t("5 seconds")}</option>
+          <option value="8">{t("8 seconds")}</option>
+          <option value="15">{t("15 seconds")}</option>
+          <option value="30">{t("30 seconds")}</option>
+        </select>
+        <p className="hint">{t("The message is held in this browser and has not been submitted yet, so taking it back costs nothing.")}</p>
+      </div>
+      <Switch checked={s.attachmentReminder} onChange={(v) => update({ attachmentReminder: v })} label={t("Attachment reminder")} hint={t("Warn when the message mentions an attachment but none is attached.")} />
+      <Switch checked={s.confirmDelete} onChange={(v) => update({ confirmDelete: v })} label={t("Confirm before deleting")} />
+    </div>
+  );
+}

--- a/web/src/views/settings/SettingsView.tsx
+++ b/web/src/views/settings/SettingsView.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, type ReactNode } from "react";
 import { Link, useLocation } from "wouter";
-import { ArrowLeft, Bell, Filter, Folder, Info, Keyboard, LayoutTemplate, Palette, PenLine, Plane, Settings as SettingsIcon, ShieldCheck, Tag, Users, Calendar } from "lucide-react";
+import { ArrowLeft, Bell, EyeOff, Filter, Folder, Info, Keyboard, LayoutTemplate, Palette, PenLine, Plane, Settings as SettingsIcon, ShieldCheck, Tag, Users, Calendar } from "lucide-react";
 import { Spinner } from "@/ui/misc";
 import { GeneralSettings } from "./GeneralSettings";
 import { AppearanceSettings } from "./AppearanceSettings";
@@ -9,6 +9,7 @@ import { FoldersSettings } from "./FoldersSettings";
 import { LabelsSettings } from "./LabelsSettings";
 import { TemplatesSettings } from "./TemplatesSettings";
 import { NotificationsSettings } from "./NotificationsSettings";
+import { PrivacySettings } from "./PrivacySettings";
 import { SecuritySettings } from "./SecuritySettings";
 import { AboutSettings } from "./AboutSettings";
 import { ShortcutsSettings } from "./ShortcutsSettings";
@@ -29,6 +30,7 @@ const SECTIONS: Array<{ id: string; label: string; icon: ReactNode; el: ReactNod
   { id: "templates", label: "Templates", icon: <LayoutTemplate size={18} />, el: <TemplatesSettings /> },
   { id: "calendar", label: "Calendar & contacts", icon: <Calendar size={18} />, el: <CalendarSettings /> },
   { id: "notifications", label: "Notifications", icon: <Bell size={18} />, el: <NotificationsSettings /> },
+  { id: "privacy", label: "Privacy & safety", icon: <EyeOff size={18} />, el: <PrivacySettings /> },
   { id: "security", label: "Security & sessions", icon: <ShieldCheck size={18} />, el: <SecuritySettings /> },
   { id: "shortcuts", label: "Keyboard shortcuts", icon: <Keyboard size={18} />, el: <ShortcutsSettings /> },
   { id: "about", label: "About", icon: <Info size={18} />, el: <AboutSettings /> },

--- a/web/src/views/settings/__tests__/privacy-settings.test.tsx
+++ b/web/src/views/settings/__tests__/privacy-settings.test.tsx
@@ -1,0 +1,107 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { PrivacySettings } from "../PrivacySettings";
+import { GeneralSettings } from "../GeneralSettings";
+import { useSettings, DEFAULT_SETTINGS } from "@/store/settings";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * The point of the section is that nothing was lost on the way out of General.
+ * A setting that stops being reachable is still stored, still applied, and
+ * impossible to change -- which is worse than leaving it where it was.
+ */
+describe("Privacy & safety", () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  const render = async (el: React.ReactNode) => {
+    await act(async () => {
+      root.render(el);
+    });
+  };
+
+  beforeEach(() => {
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    root = createRoot(host);
+    useSettings.setState({ settings: { ...DEFAULT_SETTINGS } });
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    host.remove();
+  });
+
+  it("offers every control that left General", async () => {
+    await render(<PrivacySettings />);
+    const text = host.textContent ?? "";
+    expect(text).toContain("Remote images");
+    expect(text).toContain("Always request read receipts");
+    expect(text).toContain("When someone requests a read receipt");
+    expect(text).toContain("Undo send window");
+    expect(text).toContain("Attachment reminder");
+    expect(text).toContain("Confirm before deleting");
+  });
+
+  it("leaves none of them behind in General", async () => {
+    await render(<GeneralSettings />);
+    const text = host.textContent ?? "";
+    for (const gone of [
+      "Remote images",
+      "Always request read receipts",
+      "When someone requests a read receipt",
+      "Undo send window",
+      "Attachment reminder",
+      "Confirm before deleting",
+    ]) {
+      expect(text, `${gone} is in both sections`).not.toContain(gone);
+    }
+  });
+
+  it("keeps General's own settings where they were", async () => {
+    await render(<GeneralSettings />);
+    const text = host.textContent ?? "";
+    expect(text).toContain("Reading pane");
+    expect(text).toContain("Conversation view");
+    expect(text).toContain("Default format");
+    expect(text).toContain("Spell check while typing");
+  });
+
+  it("writes through to the same stored settings the old controls used", async () => {
+    await render(<PrivacySettings />);
+    const select = [...host.querySelectorAll("select")].find((el) =>
+      [...el.options].some((o) => o.value === "always"),
+    );
+    expect(select, "remote images select").toBeTruthy();
+    await act(async () => {
+      select!.value = "always";
+      select!.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    expect(useSettings.getState().settings.imagePolicy).toBe("always");
+  });
+
+  it("hides the trusted-sender list until there is one", async () => {
+    await render(<PrivacySettings />);
+    expect(host.textContent).not.toContain("Always showing images from");
+
+    await act(async () => {
+      useSettings.setState({ settings: { ...DEFAULT_SETTINGS, trustedImageSenders: ["ada@example.com"] } });
+    });
+    await render(<PrivacySettings />);
+    expect(host.textContent).toContain("Always showing images from");
+    expect(host.textContent).toContain("ada@example.com");
+  });
+
+  it("removes a trusted sender, which nothing outside a message could do before", async () => {
+    useSettings.setState({ settings: { ...DEFAULT_SETTINGS, trustedImageSenders: ["ada@example.com", "bob@example.com"] } });
+    await render(<PrivacySettings />);
+    const remove = host.querySelector<HTMLButtonElement>('button[aria-label*="ada@example.com"]');
+    expect(remove, "remove button").toBeTruthy();
+    await act(async () => {
+      remove!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(useSettings.getState().settings.trustedImageSenders).toEqual(["bob@example.com"]);
+  });
+});


### PR DESCRIPTION
General had grown five unrelated headings and had become where anything without an obvious home ended up. Remote images were filed under "Reading", the read-receipt policy under "Composing", the undo-send window beside the default message format. They are the same kind of decision — what reaches a sender, and what asks before something happens — and they were the hardest settings in the app to find.

## What moved

Six settings, into **Privacy & safety**, in three groups:

| Group | Holds |
| --- | --- |
| Remote content | Remote images policy, and the senders trusted with them |
| Read receipts | Requesting them, and answering them |
| Before it happens | Undo-send window, attachment reminder, confirm-before-delete |

General keeps what it is actually about and is 31 lines shorter (244 → 213).

**Nothing moved in storage.** Settings are a flat object in `settings.json`; sections are only how they are grouped on screen. No migration, no key renames, no sync concern.

## The boundary against Security & sessions

Worth stating explicitly, because two similar words adjacent in a nav is how a menu becomes something people hunt through:

- **Security & sessions** — credentials and access: password, two-factor state, app passwords, live sessions.
- **Privacy & safety** — how the app behaves towards the reader and towards senders: what loads, what leaks, what asks first.

Icon is `EyeOff`, deliberately not a second shield.

## Two things beyond the move

**Trusted senders are now reviewable.** A sender was added to the remote-image allow-list from a message, and could then only be removed by finding *another* message from that same sender. They are listed here and withdrawable one at a time. This is new behaviour rather than a move — flagging it since it was not in the original scope.

**Fixed a false statement in General's lead.** It said settings are "stored in this browser", which is only true when the server has no FileNode support. They normally live in the account's own Files and follow it between devices — so the sentence contradicted the feature it sat above.

## Testing

6 component tests, including the one that matters for a move like this: that no setting is reachable in *neither* section. A setting that stops being reachable is still stored and still applied, which is worse than leaving it where it was. Also asserts the write-through still lands on the same stored keys, and covers the trusted-sender add/remove.

Suite green: web 609, server 110, typecheck clean.

## Verified

Section renders and the `/settings/privacy` deep link resolves directly — checked in the running app against the mock.

The trusted-sender chip list was **not** seen rendered: I could not get a message to open under browser automation this run. It reuses `.chip`/`.chip-x`, already proven by the composer's recipient chips, and both add and remove are covered by tests — but it is worth one look before merge.

## Note

This is a prerequisite for the three sender/link warnings, which land in this section.