### PR TITLE
Say the Archive folder needs the role, not the name

### DIFF
--- a/web/src/locales/de.ts
+++ b/web/src/locales/de.ts
@@ -986,7 +986,7 @@ export const catalog: Catalog = {
     "New all-day event on {date}": "Neuer ganztägiger Termin am {date}",
     "New event at {time}": "Neuer Termin um {time}",
     "New identity": "Neue Absenderidentität",
-    "No Archive folder found. Create one named “Archive” first.": "Kein Archivordner gefunden. Legen Sie zuerst einen mit dem Namen „Archive“ an.",
+    "No Archive folder is set. A folder needs the Archive role on the server; naming it “Archive” is not enough.": "Kein Archivordner festgelegt. Ein Ordner braucht auf dem Server die Rolle „Archive“; ihn so zu benennen genügt nicht.",
     "No contacts yet": "Noch keine Kontakte",
     "No longer shared": "Nicht mehr freigegeben",
     "No matches": "Keine Treffer",

--- a/web/src/locales/es.ts
+++ b/web/src/locales/es.ts
@@ -959,7 +959,7 @@ export const catalog: Catalog = {
     "New all-day event on {date}": "Nuevo evento de todo el día el {date}",
     "New event at {time}": "Nuevo evento a las {time}",
     "New identity": "Nueva identidad",
-    "No Archive folder found. Create one named “Archive” first.": "No se encontró una carpeta de archivo. Cree primero una llamada «Archive».",
+    "No Archive folder is set. A folder needs the Archive role on the server; naming it “Archive” is not enough.": "No hay carpeta de archivo definida. Una carpeta necesita el rol «Archive» en el servidor; no basta con llamarla así.",
     "No contacts yet": "Aún no hay contactos",
     "No longer shared": "Ya no está compartido",
     "No matches": "Sin coincidencias",

--- a/web/src/locales/fr.ts
+++ b/web/src/locales/fr.ts
@@ -964,7 +964,7 @@ export const catalog: Catalog = {
     "New all-day event on {date}": "Nouvel événement sur la journée du {date}",
     "New event at {time}": "Nouvel événement à {time}",
     "New identity": "Nouvelle identité",
-    "No Archive folder found. Create one named “Archive” first.": "Aucun dossier d’archive trouvé. Créez-en d’abord un nommé « Archive ».",
+    "No Archive folder is set. A folder needs the Archive role on the server; naming it “Archive” is not enough.": "Aucun dossier d’archive défini. Un dossier doit avoir le rôle « Archive » sur le serveur ; le nommer ainsi ne suffit pas.",
     "No contacts yet": "Pas encore de contacts",
     "No longer shared": "N’est plus partagé",
     "No matches": "Aucune correspondance",

--- a/web/src/locales/ja.ts
+++ b/web/src/locales/ja.ts
@@ -967,7 +967,7 @@ export const catalog: Catalog = {
     "New all-day event on {date}": "{date} に終日の予定を作成",
     "New event at {time}": "{time} に予定を作成",
     "New identity": "新しい差出人",
-    "No Archive folder found. Create one named “Archive” first.": "アーカイブフォルダーが見つかりません。先に「Archive」という名前で作成してください。",
+    "No Archive folder is set. A folder needs the Archive role on the server; naming it “Archive” is not enough.": "アーカイブフォルダーが設定されていません。サーバーでフォルダーに「Archive」ロールが必要です。名前をそうするだけでは不十分です。",
     "No contacts yet": "連絡先がまだありません",
     "No longer shared": "共有を解除しました",
     "No matches": "一致するものがありません",

--- a/web/src/locales/nl.ts
+++ b/web/src/locales/nl.ts
@@ -955,7 +955,7 @@ export const catalog: Catalog = {
     "New all-day event on {date}": "Nieuwe hele dag durende afspraak op {date}",
     "New event at {time}": "Nieuwe afspraak om {time}",
     "New identity": "Nieuwe afzender",
-    "No Archive folder found. Create one named “Archive” first.": "Geen archiefmap gevonden. Maak er eerst een met de naam ‘Archive’.",
+    "No Archive folder is set. A folder needs the Archive role on the server; naming it “Archive” is not enough.": "Geen archiefmap ingesteld. Een map heeft op de server de rol ‘Archive’ nodig; die naam geven is niet genoeg.",
     "No contacts yet": "Nog geen contacten",
     "No longer shared": "Niet langer gedeeld",
     "No matches": "Geen overeenkomsten",

--- a/web/src/locales/pt-BR.ts
+++ b/web/src/locales/pt-BR.ts
@@ -962,7 +962,7 @@ export const catalog: Catalog = {
     "New all-day event on {date}": "Novo evento de dia inteiro em {date}",
     "New event at {time}": "Novo evento às {time}",
     "New identity": "Nova identidade",
-    "No Archive folder found. Create one named “Archive” first.": "Nenhuma pasta de arquivamento encontrada. Crie uma chamada “Archive” primeiro.",
+    "No Archive folder is set. A folder needs the Archive role on the server; naming it “Archive” is not enough.": "Nenhuma pasta de arquivamento definida. Uma pasta precisa da função “Archive” no servidor; nomeá-la assim não basta.",
     "No contacts yet": "Ainda não há contatos",
     "No longer shared": "Não está mais compartilhado",
     "No matches": "Nenhuma correspondência",

--- a/web/src/locales/ru.ts
+++ b/web/src/locales/ru.ts
@@ -961,7 +961,7 @@ export const catalog: Catalog = {
     "New all-day event on {date}": "Новое событие на весь день {date}",
     "New event at {time}": "Новое событие в {time}",
     "New identity": "Новый профиль отправителя",
-    "No Archive folder found. Create one named “Archive” first.": "Папка архива не найдена. Сначала создайте папку с именем «Archive».",
+    "No Archive folder is set. A folder needs the Archive role on the server; naming it “Archive” is not enough.": "Папка архива не задана. На сервере папке нужна роль «Archive»; просто назвать её так недостаточно.",
     "No contacts yet": "Контактов пока нет",
     "No longer shared": "Общий доступ прекращён",
     "No matches": "Совпадений нет",

--- a/web/src/locales/uk.ts
+++ b/web/src/locales/uk.ts
@@ -955,7 +955,7 @@ export const catalog: Catalog = {
     "New all-day event on {date}": "Нова подія на весь день {date}",
     "New event at {time}": "Нова подія о {time}",
     "New identity": "Новий профіль відправника",
-    "No Archive folder found. Create one named “Archive” first.": "Теку архіву не знайдено. Спершу створіть теку з назвою «Archive».",
+    "No Archive folder is set. A folder needs the Archive role on the server; naming it “Archive” is not enough.": "Теку архіву не задано. На сервері теці потрібна роль «Archive»; просто назвати її так недостатньо.",
     "No contacts yet": "Контактів ще немає",
     "No longer shared": "Спільний доступ припинено",
     "No matches": "Збігів немає",

--- a/web/src/locales/zh-Hans.ts
+++ b/web/src/locales/zh-Hans.ts
@@ -966,7 +966,7 @@ export const catalog: Catalog = {
     "New all-day event on {date}": "在 {date} 新建全天日程",
     "New event at {time}": "在 {time} 新建日程",
     "New identity": "新建发件身份",
-    "No Archive folder found. Create one named “Archive” first.": "未找到归档文件夹。请先创建一个名为「Archive」的文件夹。",
+    "No Archive folder is set. A folder needs the Archive role on the server; naming it “Archive” is not enough.": "未设置归档文件夹。文件夹需要在服务器上具有「Archive」角色，仅命名为此并不够。",
     "No contacts yet": "还没有联系人",
     "No longer shared": "已停止共享",
     "No matches": "没有匹配项",

--- a/web/src/store/__tests__/archive-by-date.test.ts
+++ b/web/src/store/__tests__/archive-by-date.test.ts
@@ -177,6 +177,15 @@ describe("archiveByDate", () => {
     expect(s.created).toEqual([]);
     expect(s.moves).toEqual([]);
     expect(messages()[0]).toContain("No Archive folder");
+    /*
+     * What it says, not just that it complains. The folder is found by its
+     * special-use role and by nothing else, so telling someone to create a
+     * folder *named* "Archive" sent them round a loop that could not end --
+     * naming a folder does not give it the role, and ihasmail cannot assign
+     * one. Issue #217.
+     */
+    expect(messages()[0]).toContain("role");
+    expect(messages()[0]).not.toMatch(/Create one named/);
   });
 
   it("has nothing to do with an empty selection", async () => {

--- a/web/src/store/mail.ts
+++ b/web/src/store/mail.ts
@@ -610,7 +610,7 @@ export const useMail = create<MailState>((set, get) => ({
   async archive(ids) {
     const archiveId = get().roleId("archive") ?? get().roleId("all");
     if (!archiveId) {
-      toast.error(t("No Archive folder found. Create one named “Archive” first."));
+      toast.error(t("No Archive folder is set. A folder needs the Archive role on the server; naming it “Archive” is not enough."));
       return;
     }
     await get().move(ids, archiveId, { label: "Archive" });
@@ -621,7 +621,7 @@ export const useMail = create<MailState>((set, get) => ({
     const archiveId = get().roleId("archive") ?? get().roleId("all");
     if (!accountId || !ids.length) return;
     if (!archiveId) {
-      toast.error(t("No Archive folder found. Create one named “Archive” first."));
+      toast.error(t("No Archive folder is set. A folder needs the Archive role on the server; naming it “Archive” is not enough."));
       return;
     }
     const { emails } = get();


### PR DESCRIPTION
Fixes #217.

Archiving looks the folder up by its special-use role and by nothing else — `roleId("archive")`, falling back to `roleId("all")` — and then, finding neither, told you:

> No Archive folder found. Create one named “Archive” first.

Naming a folder does not give it a role, and ihasmail has no way to assign one: Folders settings shows a folder's role beside it and offers no control to set it. So the advice sent someone round a loop that could not end — they make the folder, it still does not work, and the message says the same thing again.

It now says what is actually required and where it lives:

> No Archive folder is set. A folder needs the Archive role on the server; naming it “Archive” is not enough.

Both call sites — `archive` and `archiveByDate` — used the same string and both change.

All nine catalogues carry the correction rather than falling back to visible English. They need the same native review the rest of the catalogue does; the correction they carry is the same one the English makes.

The existing test asserted only that archiving complained. It now checks what the complaint says, since the words were the whole bug.

`npm run typecheck`, `npm test` (897 web + 122 server), `npm run build`, `npm run i18n:check` (no new stale or missing keys) all pass.

## Not in this PR

Letting ihasmail assign the role itself — a "make this the Archive folder" control in Folders settings — would remove the need for the message entirely. JMAP allows `role` on `Mailbox/set`, but whether Stalwart accepts it is not something I've confirmed against a live server, so it isn't built on the assumption.