### PR TITLE
Prune old images, and keep every release

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,68 @@
+# Prune old image versions from GHCR.
+#
+# Releases are kept forever -- they carry no assets and their generated notes
+# are this project's only changelog, so deleting one destroys history that
+# cannot be reconstructed for nothing saved. Images are the opposite: a
+# multi-arch build a week, and the by-digest push in publish.yml leaves two
+# untagged per-architecture manifests behind each time on top of the tagged
+# index. Those accumulate and nobody wants fifty of them.
+#
+# THE FOOTGUN: the obvious tool for this -- delete-package-versions with
+# `delete-only-untagged-versions` -- will happily delete the per-architecture
+# manifests that a multi-arch tag points *at*, because they are untagged by
+# design. Nothing appears to break: the tag still exists, and pulls simply
+# start failing for one architecture. This action understands manifest lists
+# and will not orphan a retained index, and `validate` re-checks every
+# multi-arch manifest against the registry afterwards.
+#
+# Separate from publish.yml, and dispatchable on its own, so `dry_run` can show
+# exactly what would be deleted without rebuilding and re-pushing an image to
+# find out.
+name: Prune images
+
+on:
+  workflow_call:
+    inputs:
+      dry_run:
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "List what would be deleted, delete nothing"
+        type: boolean
+        default: true
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      # Pinned to a commit rather than a moving major tag. This action is
+      # handed `packages: write` and its whole job is deletion, so a tag
+      # repointed at something else -- by a compromise or a mistake upstream --
+      # is a bad day. v1.2.2.
+      - uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f
+        with:
+          owner: Coffey-Labs
+          package: ihasmail
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Ten weekly releases is roughly a quarter of history, which is more
+          # than enough to roll back to and far less than the year's worth that
+          # would otherwise pile up. Older *releases* stay either way; this
+          # only removes the images.
+          keep-n-tagged: 10
+          # Belt and braces on top of the action's own manifest awareness:
+          # `latest` is never a candidate for deletion under any counting.
+          exclude-tags: latest
+          delete-untagged: true
+          # Sweeps the wreckage of a half-failed run: an index whose platform
+          # images did not all land, and referrers whose parent is gone.
+          delete-partial-images: true
+          delete-orphaned-images: true
+          # Checks every remaining multi-architecture manifest still resolves
+          # in the registry. This is the step that would catch the footgun
+          # above rather than leaving a reader to discover it on `docker pull`.
+          validate: true
+          dry-run: ${{ inputs.dry_run }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -192,3 +192,11 @@ jobs:
           docker buildx imagetools create "${tags[@]}" "${refs[@]}"
       - name: Show what landed
         run: docker buildx imagetools inspect "${IMAGE}:${{ needs.version.outputs.docker_tag }}"
+
+  # Runs only after a successful publish, because that is the only moment the
+  # package grows. See cleanup.yml for why this is not the obvious one-liner.
+  prune:
+    needs: publish
+    permissions:
+      packages: write
+    uses: ./.github/workflows/cleanup.yml


### PR DESCRIPTION
Follow-up to #244 and #245. Two artefacts, opposite answers.

## Releases stay — all of them

They carry **no assets** (`v2026.9.2-pr244` has zero; the image lives in GHCR), so a release is a tag, a title and generated notes. And there is **no `CHANGELOG` file in this repository**, which makes those generated notes the only changelog the project has.

Deleting one destroys history that cannot be reconstructed and saves nothing. Rollback would survive — deleting a release does not delete its tag — but the record of what was in it would not.

## Images get pruned

A multi-arch build a week, and the by-digest push in `publish.yml` leaves **two untagged per-architecture manifests** behind each time on top of the tagged index. Ten tagged versions kept — roughly a quarter of a year, and far more than anything anyone rolls back to.

## The trap

The obvious tool is `actions/delete-package-versions` with `delete-only-untagged-versions: true`. It will delete the **per-architecture manifests that a multi-arch tag points at**, because they are untagged by design.

Nothing appears to break. The tag still resolves. Pulls just start failing for one architecture, at some later date, for a reason nobody connects to a cleanup job that ran weeks earlier.

`dataaxiom/ghcr-cleanup-action` understands manifest lists and will not orphan a retained index. On top of that:

- `validate: true` re-checks every remaining multi-arch manifest against the registry after the sweep — the step that would *catch* the footgun rather than leave it to be discovered on `docker pull`
- `exclude-tags: latest` takes `latest` out of consideration under any counting
- `delete-partial-images` / `delete-orphaned-images` sweep the wreckage of a half-failed run

## Pinned to a commit

`@d52806a0` (v1.2.2), not `@v1`. This action is handed `packages: write` and its entire purpose is deletion; a tag repointed upstream — by compromise or mistake — is not a risk worth carrying for the convenience of a floating major.

## Its own file, on purpose

`cleanup.yml` is `workflow_call` **and** `workflow_dispatch`, with `dry_run` defaulting to **true** on manual runs. That means the deletion list can be inspected without rebuilding and re-pushing an image to trigger it.

## Testing

`actionlint` clean across all three workflows. After merge I'll dispatch it with `dry_run: true` and read exactly what it proposes to delete before anything runs for real — and confirm both architectures still resolve afterwards.