### PR TITLE
Second pass: four dialogs that were never wrapped

### DIFF
--- a/web/src/views/contacts/ContactsSidebar.tsx
+++ b/web/src/views/contacts/ContactsSidebar.tsx
@@ -114,7 +114,7 @@ export function ContactsSidebar() {
           title={t("New address book")}
           aria-label={t("New address book")}
           onClick={async () => {
-            const name = await promptDialog({ title: "New address book", placeholder: "Name" });
+            const name = await promptDialog({ title: t("New address book"), placeholder: t("Name") });
             if (!name?.trim()) return;
             try {
               await contacts.createBook(name.trim());

--- a/web/src/views/files/FilesTree.tsx
+++ b/web/src/views/files/FilesTree.tsx
@@ -257,7 +257,7 @@ export function FilesTree() {
               label={t("Rename")}
               disabled={!menuNode.myRights?.mayRename}
               onClick={async () => {
-                const name = await promptDialog({ title: "Rename", defaultValue: menuNode.name });
+                const name = await promptDialog({ title: t("Rename"), defaultValue: menuNode.name });
                 if (!name?.trim() || name === menuNode.name) return;
                 try {
                   await useFiles.getState().rename(menuNode.id, name.trim());

--- a/web/src/views/mail/MailView.tsx
+++ b/web/src/views/mail/MailView.tsx
@@ -228,7 +228,16 @@ export function MailView({ mailboxId, threadId, search }: { mailboxId?: string; 
         const trashId = mail.roleId("trash");
         const permanent = t.every((id) => trashId && mail.emails[id]?.mailboxIds[trashId]);
         if (permanent || settings.confirmDelete) {
-          const ok = await confirmDialog({ title: permanent ? "Delete forever?" : "Delete?", message: permanent ? `${t.length} message(s) will be permanently deleted.` : `Move ${t.length} message(s) to Trash?`, confirmLabel: "Delete", danger: permanent });
+          // "message(s)" was doing the work a plural form should: every
+          // language that inflects got a parenthesis instead of agreement.
+          const ok = await confirmDialog({
+            title: permanent ? translate("Delete forever?") : translate("Delete?"),
+            message: permanent
+              ? plural(t.length, { one: "{n} message will be permanently deleted.", other: "{n} messages will be permanently deleted." })
+              : plural(t.length, { one: "Move {n} message to Trash?", other: "Move {n} messages to Trash?" }),
+            confirmLabel: translate("Delete"),
+            danger: permanent,
+          });
           if (!ok) return;
         }
         await mail.trash(t);

--- a/web/src/views/settings/CalendarSettings.tsx
+++ b/web/src/views/settings/CalendarSettings.tsx
@@ -60,7 +60,7 @@ export function CalendarSettings() {
           <div style={{ marginTop: 8 }}><ColorSwatches value={c.color} onChange={(col) => update({ eventCategories: s.eventCategories.map((x, j) => (j === i ? { ...x, color: col } : x)) })} /></div>
         </div>
       ))}
-      <button className="btn mb-16" onClick={async () => { const n = await promptDialog({ title: "New category", placeholder: "Name" }); if (n?.trim() && !s.eventCategories.some((c) => c.name.toLowerCase() === n.trim().toLowerCase())) update({ eventCategories: [...s.eventCategories, { name: n.trim(), color: CALENDAR_COLORS[s.eventCategories.length % CALENDAR_COLORS.length]! }] }); }}><Plus size={16} />  {t("New category")}</button>
+      <button className="btn mb-16" onClick={async () => { const n = await promptDialog({ title: t("New category"), placeholder: t("Name") }); if (n?.trim() && !s.eventCategories.some((c) => c.name.toLowerCase() === n.trim().toLowerCase())) update({ eventCategories: [...s.eventCategories, { name: n.trim(), color: CALENDAR_COLORS[s.eventCategories.length % CALENDAR_COLORS.length]! }] }); }}><Plus size={16} />  {t("New category")}</button>
 
       <h2>{t("Subscribed calendars")}</h2>
       <p className="hint" style={{ marginTop: -8 }}>


### PR DESCRIPTION
A sweep for UI text still rendering in English, after the nine catalogues were brought up to date.

## What was still hardcoded

| Where | What |
|---|---|
| `MailView` delete confirmation | **entirely** — both titles, both messages, the confirm label |
| `FilesTree` | `Rename` |
| `ContactsSidebar` | `New address book`, and its `Name` placeholder |
| `CalendarSettings` | `New category`, and its `Name` placeholder |

The delete confirmation is the notable one. Its counts read `"message(s)"` — a parenthesis standing in for grammatical agreement, so every language that inflects got the wrong form regardless of catalogue coverage. Those are `plural()` calls now.

The `New category` case shows how these hide: the button that opens the dialog was already translated, so the label read correctly and the dialog it opened did not.

## Strings

`Rename`, `New address book`, `New category`, `Name` and `Delete` are already in all nine catalogues, so those are fixed by this PR alone. `Delete?`, `Delete forever?` and the two plural forms are new and land with each language PR.

## Still outstanding — two sentence builders

The sweep found a larger class this PR does **not** fix, because it needs a design decision rather than a wrapper:

- **`lib/sieve.ts` `describeRule()`** builds the Sieve rule summaries by string concatenation — `` `${t.header} ${op} "${t.value}"` `` joined by `" and "` / `" or "`, with actions like `move to`, `forward to`, `delete`. This is exactly the "Sieve rule list — all the summaries" item in #247.
- **`lib/recurrence.ts` `describeRule()`** does the same for recurrence — `Every {n} days`, `` on the ${ordinal}${Weekday} ``, `, {n} times`, `, until {date}` — with English ordinals (`1st`, `2nd`, `last`) and English weekday names.

Neither is translatable as written: the sentence is assembled from fragments, and word order is not the same in German, Japanese or Ukrainian. Fixing them properly means whole sentences with placeholders rather than concatenation, which changes the string inventory and so needs another pass over all nine catalogues.

`WEEKDAYS` in `recurrence.ts` is related: its `short` forms cannot be catalogue keys because `T` covers both Tuesday and Thursday and `S` both Saturday and Sunday. `Intl.DateTimeFormat` with `weekday: "narrow"` is the right answer, and `lib/datetime.ts` already has a locale-aware formatter cache to hang it on.

## Checks

Typecheck clean, 99 test files / 1000 tests pass.