### PR TITLE
Add seven plural forms no catalogue ever had

### DIFF
--- a/web/src/locales/de.ts
+++ b/web/src/locales/de.ts
@@ -1318,8 +1318,20 @@ export const catalog: Catalog = {
     "{header} {op} \"{value}\"": "{header} {op} \"{value}\"",
     "{rule}, until {date}": "{rule}, bis {date}",
     "{tests} → {actions}": "{tests} → {actions}",
+    // ── Third pass ──────────────────────────────────────────────────────
+    // Sentences that lib/ and store/ were building in English, and the two
+    // swipe labels that reach t() through a variable and so were invisible
+    // to a scan for t("literal"). See #259.
   },
   plurals: {
+    // ── Third pass ─────────────────────────────────────────────────────
+    "Delete {n} items": { one: "{n} Element löschen", other: "{n} Elemente löschen" },
+    "Delete {n} items?": { one: "{n} Element löschen?", other: "{n} Elemente löschen?" },
+    "Move {n} items": { one: "{n} Element verschieben", other: "{n} Elemente verschieben" },
+    "Move {n} items…": { one: "{n} Element verschieben…", other: "{n} Elemente verschieben…" },
+    "The event runs {n} days longer than this shows.": { one: "Der Termin dauert {n} Tag länger, als hier angezeigt wird.", other: "Der Termin dauert {n} Tage länger, als hier angezeigt wird." },
+    "{n} guests are not on this server, so there is no free/busy to read for them.": { one: "{n} Gast ist nicht auf diesem Server, daher gibt es dafür keine Frei/Gebucht-Informationen.", other: "{n} Gäste sind nicht auf diesem Server, daher gibt es dafür keine Frei/Gebucht-Informationen." },
+    "{n} items selected": { one: "{n} Element ausgewählt", other: "{n} Elemente ausgewählt" },
     // ── Third pass ─────────────────────────────────────────────────────
     "Every {n} days": { one: "Jeden Tag", other: "Alle {n} Tage" },
     "Every {n} months": { one: "Jeden Monat", other: "Alle {n} Monate" },

--- a/web/src/locales/es.ts
+++ b/web/src/locales/es.ts
@@ -1291,8 +1291,20 @@ export const catalog: Catalog = {
     "{header} {op} \"{value}\"": "{header} {op} \"{value}\"",
     "{rule}, until {date}": "{rule}, hasta el {date}",
     "{tests} → {actions}": "{tests} → {actions}",
+    // ── Third pass ──────────────────────────────────────────────────────
+    // Sentences that lib/ and store/ were building in English, and the two
+    // swipe labels that reach t() through a variable and so were invisible
+    // to a scan for t("literal"). See #259.
   },
   plurals: {
+    // ── Third pass ─────────────────────────────────────────────────────
+    "Delete {n} items": { one: "Eliminar {n} elemento", other: "Eliminar {n} elementos" },
+    "Delete {n} items?": { one: "¿Eliminar {n} elemento?", other: "¿Eliminar {n} elementos?" },
+    "Move {n} items": { one: "Mover {n} elemento", other: "Mover {n} elementos" },
+    "Move {n} items…": { one: "Mover {n} elemento…", other: "Mover {n} elementos…" },
+    "The event runs {n} days longer than this shows.": { one: "El evento dura {n} día más de lo que se muestra aquí.", other: "El evento dura {n} días más de lo que se muestra aquí." },
+    "{n} guests are not on this server, so there is no free/busy to read for them.": { one: "{n} invitado no está en este servidor, así que no hay información de libre/ocupado para él.", other: "{n} invitados no están en este servidor, así que no hay información de libre/ocupado para ellos." },
+    "{n} items selected": { one: "{n} elemento seleccionado", other: "{n} elementos seleccionados" },
     // ── Third pass ─────────────────────────────────────────────────────
     "Every {n} days": { one: "Cada día", other: "Cada {n} días" },
     "Every {n} months": { one: "Cada mes", other: "Cada {n} meses" },

--- a/web/src/locales/fr.ts
+++ b/web/src/locales/fr.ts
@@ -1296,8 +1296,20 @@ export const catalog: Catalog = {
     "{header} {op} \"{value}\"": "{header} {op} \"{value}\"",
     "{rule}, until {date}": "{rule}, jusqu'au {date}",
     "{tests} → {actions}": "{tests} → {actions}",
+    // ── Third pass ──────────────────────────────────────────────────────
+    // Sentences that lib/ and store/ were building in English, and the two
+    // swipe labels that reach t() through a variable and so were invisible
+    // to a scan for t("literal"). See #259.
   },
   plurals: {
+    // ── Third pass ─────────────────────────────────────────────────────
+    "Delete {n} items": { one: "Supprimer {n} élément", other: "Supprimer {n} éléments" },
+    "Delete {n} items?": { one: "Supprimer {n} élément ?", other: "Supprimer {n} éléments ?" },
+    "Move {n} items": { one: "Déplacer {n} élément", other: "Déplacer {n} éléments" },
+    "Move {n} items…": { one: "Déplacer {n} élément…", other: "Déplacer {n} éléments…" },
+    "The event runs {n} days longer than this shows.": { one: "L'événement dure {n} jour de plus que ce qui est affiché ici.", other: "L'événement dure {n} jours de plus que ce qui est affiché ici." },
+    "{n} guests are not on this server, so there is no free/busy to read for them.": { one: "{n} invité n'est pas sur ce serveur, il n'y a donc pas de disponibilité à lire pour lui.", other: "{n} invités ne sont pas sur ce serveur, il n'y a donc pas de disponibilité à lire pour eux." },
+    "{n} items selected": { one: "{n} élément sélectionné", other: "{n} éléments sélectionnés" },
     // ── Third pass ─────────────────────────────────────────────────────
     "Every {n} days": { one: "Chaque jour", other: "Tous les {n} jours" },
     "Every {n} months": { one: "Chaque mois", other: "Tous les {n} mois" },

--- a/web/src/locales/ja.ts
+++ b/web/src/locales/ja.ts
@@ -1299,8 +1299,20 @@ export const catalog: Catalog = {
     "{header} {op} \"{value}\"": "{header} が \"{value}\" を{op}",
     "{rule}, until {date}": "{rule}（{date} まで）",
     "{tests} → {actions}": "{tests} → {actions}",
+    // ── Third pass ──────────────────────────────────────────────────────
+    // Sentences that lib/ and store/ were building in English, and the two
+    // swipe labels that reach t() through a variable and so were invisible
+    // to a scan for t("literal"). See #259.
   },
   plurals: {
+    // ── Third pass ─────────────────────────────────────────────────────
+    "Delete {n} items": { other: "{n} 件を削除" },
+    "Delete {n} items?": { other: "{n} 件を削除しますか？" },
+    "Move {n} items": { other: "{n} 件を移動" },
+    "Move {n} items…": { other: "{n} 件を移動…" },
+    "The event runs {n} days longer than this shows.": { other: "この予定は表示よりも {n} 日長く続きます。" },
+    "{n} guests are not on this server, so there is no free/busy to read for them.": { other: "{n} 名の参加者はこのサーバーにいないため、空き情報を取得できません。" },
+    "{n} items selected": { other: "{n} 件を選択中" },
     // ── Third pass ─────────────────────────────────────────────────────
     "Every {n} days": { other: "{n} 日ごと" },
     "Every {n} months": { other: "{n} か月ごと" },

--- a/web/src/locales/nl.ts
+++ b/web/src/locales/nl.ts
@@ -1287,8 +1287,20 @@ export const catalog: Catalog = {
     "{header} {op} \"{value}\"": "{header} {op} \"{value}\"",
     "{rule}, until {date}": "{rule}, tot {date}",
     "{tests} → {actions}": "{tests} → {actions}",
+    // ── Third pass ──────────────────────────────────────────────────────
+    // Sentences that lib/ and store/ were building in English, and the two
+    // swipe labels that reach t() through a variable and so were invisible
+    // to a scan for t("literal"). See #259.
   },
   plurals: {
+    // ── Third pass ─────────────────────────────────────────────────────
+    "Delete {n} items": { one: "{n} item verwijderen", other: "{n} items verwijderen" },
+    "Delete {n} items?": { one: "{n} item verwijderen?", other: "{n} items verwijderen?" },
+    "Move {n} items": { one: "{n} item verplaatsen", other: "{n} items verplaatsen" },
+    "Move {n} items…": { one: "{n} item verplaatsen…", other: "{n} items verplaatsen…" },
+    "The event runs {n} days longer than this shows.": { one: "De gebeurtenis duurt {n} dag langer dan hier wordt getoond.", other: "De gebeurtenis duurt {n} dagen langer dan hier wordt getoond." },
+    "{n} guests are not on this server, so there is no free/busy to read for them.": { one: "{n} gast zit niet op deze server, dus er is geen vrij/bezet voor die persoon te lezen.", other: "{n} gasten zitten niet op deze server, dus er is geen vrij/bezet voor hen te lezen." },
+    "{n} items selected": { one: "{n} item geselecteerd", other: "{n} items geselecteerd" },
     // ── Third pass ─────────────────────────────────────────────────────
     "Every {n} days": { one: "Elke dag", other: "Elke {n} dagen" },
     "Every {n} months": { one: "Elke maand", other: "Elke {n} maanden" },

--- a/web/src/locales/pt-BR.ts
+++ b/web/src/locales/pt-BR.ts
@@ -1294,8 +1294,20 @@ export const catalog: Catalog = {
     "{header} {op} \"{value}\"": "{header} {op} \"{value}\"",
     "{rule}, until {date}": "{rule}, até {date}",
     "{tests} → {actions}": "{tests} → {actions}",
+    // ── Third pass ──────────────────────────────────────────────────────
+    // Sentences that lib/ and store/ were building in English, and the two
+    // swipe labels that reach t() through a variable and so were invisible
+    // to a scan for t("literal"). See #259.
   },
   plurals: {
+    // ── Third pass ─────────────────────────────────────────────────────
+    "Delete {n} items": { one: "Excluir {n} item", other: "Excluir {n} itens" },
+    "Delete {n} items?": { one: "Excluir {n} item?", other: "Excluir {n} itens?" },
+    "Move {n} items": { one: "Mover {n} item", other: "Mover {n} itens" },
+    "Move {n} items…": { one: "Mover {n} item…", other: "Mover {n} itens…" },
+    "The event runs {n} days longer than this shows.": { one: "O evento dura {n} dia a mais do que é exibido aqui.", other: "O evento dura {n} dias a mais do que é exibido aqui." },
+    "{n} guests are not on this server, so there is no free/busy to read for them.": { one: "{n} convidado não está neste servidor, então não há livre/ocupado a consultar para ele.", other: "{n} convidados não estão neste servidor, então não há livre/ocupado a consultar para eles." },
+    "{n} items selected": { one: "{n} item selecionado", other: "{n} itens selecionados" },
     // ── Third pass ─────────────────────────────────────────────────────
     "Every {n} days": { one: "Todo dia", other: "A cada {n} dias" },
     "Every {n} months": { one: "Todo mês", other: "A cada {n} meses" },

--- a/web/src/locales/ru.ts
+++ b/web/src/locales/ru.ts
@@ -1293,8 +1293,20 @@ export const catalog: Catalog = {
     "{header} {op} \"{value}\"": "{header} {op} \"{value}\"",
     "{rule}, until {date}": "{rule}, до {date}",
     "{tests} → {actions}": "{tests} → {actions}",
+    // ── Third pass ──────────────────────────────────────────────────────
+    // Sentences that lib/ and store/ were building in English, and the two
+    // swipe labels that reach t() through a variable and so were invisible
+    // to a scan for t("literal"). See #259.
   },
   plurals: {
+    // ── Third pass ─────────────────────────────────────────────────────
+    "Delete {n} items": { one: "Удалить {n} объект", few: "Удалить {n} объекта", many: "Удалить {n} объектов", other: "Удалить {n} объекта" },
+    "Delete {n} items?": { one: "Удалить {n} объект?", few: "Удалить {n} объекта?", many: "Удалить {n} объектов?", other: "Удалить {n} объекта?" },
+    "Move {n} items": { one: "Переместить {n} объект", few: "Переместить {n} объекта", many: "Переместить {n} объектов", other: "Переместить {n} объекта" },
+    "Move {n} items…": { one: "Переместить {n} объект…", few: "Переместить {n} объекта…", many: "Переместить {n} объектов…", other: "Переместить {n} объекта…" },
+    "The event runs {n} days longer than this shows.": { one: "Событие длится на {n} день дольше, чем показано здесь.", few: "Событие длится на {n} дня дольше, чем показано здесь.", many: "Событие длится на {n} дней дольше, чем показано здесь.", other: "Событие длится на {n} дня дольше, чем показано здесь." },
+    "{n} guests are not on this server, so there is no free/busy to read for them.": { one: "{n} участник не на этом сервере, поэтому сведений о занятости для него нет.", few: "{n} участника не на этом сервере, поэтому сведений о занятости для них нет.", many: "{n} участников не на этом сервере, поэтому сведений о занятости для них нет.", other: "{n} участника не на этом сервере, поэтому сведений о занятости для них нет." },
+    "{n} items selected": { one: "Выбран {n} объект", few: "Выбрано {n} объекта", many: "Выбрано {n} объектов", other: "Выбрано {n} объекта" },
     // ── Third pass ─────────────────────────────────────────────────────
     "Every {n} days": { one: "Каждый день", few: "Каждые {n} дня", many: "Каждые {n} дней", other: "Каждые {n} дня" },
     "Every {n} months": { one: "Каждый месяц", few: "Каждые {n} месяца", many: "Каждые {n} месяцев", other: "Каждые {n} месяца" },

--- a/web/src/locales/uk.ts
+++ b/web/src/locales/uk.ts
@@ -1287,8 +1287,20 @@ export const catalog: Catalog = {
     "{header} {op} \"{value}\"": "{header} {op} \"{value}\"",
     "{rule}, until {date}": "{rule}, до {date}",
     "{tests} → {actions}": "{tests} → {actions}",
+    // ── Third pass ──────────────────────────────────────────────────────
+    // Sentences that lib/ and store/ were building in English, and the two
+    // swipe labels that reach t() through a variable and so were invisible
+    // to a scan for t("literal"). See #259.
   },
   plurals: {
+    // ── Third pass ─────────────────────────────────────────────────────
+    "Delete {n} items": { one: "Видалити {n} об’єкт", few: "Видалити {n} об’єкти", many: "Видалити {n} об’єктів", other: "Видалити {n} об’єкта" },
+    "Delete {n} items?": { one: "Видалити {n} об’єкт?", few: "Видалити {n} об’єкти?", many: "Видалити {n} об’єктів?", other: "Видалити {n} об’єкта?" },
+    "Move {n} items": { one: "Перемістити {n} об’єкт", few: "Перемістити {n} об’єкти", many: "Перемістити {n} об’єктів", other: "Перемістити {n} об’єкта" },
+    "Move {n} items…": { one: "Перемістити {n} об’єкт…", few: "Перемістити {n} об’єкти…", many: "Перемістити {n} об’єктів…", other: "Перемістити {n} об’єкта…" },
+    "The event runs {n} days longer than this shows.": { one: "Подія триває на {n} день довше, ніж показано тут.", few: "Подія триває на {n} дні довше, ніж показано тут.", many: "Подія триває на {n} днів довше, ніж показано тут.", other: "Подія триває на {n} дня довше, ніж показано тут." },
+    "{n} guests are not on this server, so there is no free/busy to read for them.": { one: "{n} гість не на цьому сервері, тому відомостей про зайнятість для нього немає.", few: "{n} гості не на цьому сервері, тому відомостей про зайнятість для них немає.", many: "{n} гостей не на цьому сервері, тому відомостей про зайнятість для них немає.", other: "{n} гостя не на цьому сервері, тому відомостей про зайнятість для них немає." },
+    "{n} items selected": { one: "Вибрано {n} об’єкт", few: "Вибрано {n} об’єкти", many: "Вибрано {n} об’єктів", other: "Вибрано {n} об’єкта" },
     // ── Third pass ─────────────────────────────────────────────────────
     "Every {n} days": { one: "Щодня", few: "Кожні {n} дні", many: "Кожні {n} днів", other: "Кожні {n} дня" },
     "Every {n} months": { one: "Щомісяця", few: "Кожні {n} місяці", many: "Кожні {n} місяців", other: "Кожні {n} місяця" },

--- a/web/src/locales/zh-Hans.ts
+++ b/web/src/locales/zh-Hans.ts
@@ -1298,8 +1298,20 @@ export const catalog: Catalog = {
     "{header} {op} \"{value}\"": "{header} {op} \"{value}\"",
     "{rule}, until {date}": "{rule}，直到 {date}",
     "{tests} → {actions}": "{tests} → {actions}",
+    // ── Third pass ──────────────────────────────────────────────────────
+    // Sentences that lib/ and store/ were building in English, and the two
+    // swipe labels that reach t() through a variable and so were invisible
+    // to a scan for t("literal"). See #259.
   },
   plurals: {
+    // ── Third pass ─────────────────────────────────────────────────────
+    "Delete {n} items": { other: "删除 {n} 个项目" },
+    "Delete {n} items?": { other: "要删除 {n} 个项目吗？" },
+    "Move {n} items": { other: "移动 {n} 个项目" },
+    "Move {n} items…": { other: "移动 {n} 个项目…" },
+    "The event runs {n} days longer than this shows.": { other: "此活动比这里显示的时间长 {n} 天。" },
+    "{n} guests are not on this server, so there is no free/busy to read for them.": { other: "有 {n} 位与会者不在此服务器上，因此无法读取他们的空闲/忙碌信息。" },
+    "{n} items selected": { other: "已选择 {n} 个项目" },
     // ── Third pass ─────────────────────────────────────────────────────
     "Every {n} days": { other: "每 {n} 天" },
     "Every {n} months": { other: "每 {n} 个月" },


### PR DESCRIPTION
Found by widening the coverage check to `plural()` forms in **every** file rather than only the ones being worked on.

Seven counted strings had never been in any of the nine catalogues, so they rendered in English whatever language was selected:

| String | Where |
|---|---|
| `Delete {n} items?` / `Delete {n} items` | Files view |
| `Move {n} items` / `Move {n} items…` | Files view |
| `{n} items selected` | Files view |
| `The event runs {n} days longer than this shows.` | Event editor |
| `{n} guests are not on this server…` | Event editor |

**Not a regression** from the recent work — they have been missing since those features landed. Every earlier scan looked at `t("literal")` call sites plus the plurals of whichever file was in hand, which is exactly the blind spot that also hid `Add star` earlier.

All nine languages in one commit rather than nine PRs: this is a single gap in a check, not a translation pass, and splitting it per language would imply nine decisions where there is one.

After this, a scan of **1,149 strings** — every `t()` literal, every value reaching `t()` through a variable, and every `plural()` form — reports **0 missing** in all nine catalogues.

Typecheck clean, 101 test files / 1016 tests pass.