### PR TITLE
Say in CONTRIBUTING that main is protected, and that strings need nine catalogues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,17 @@ For larger changes, please open an issue to discuss the approach **before** subm
    - Related issue number(s), if any
    - Screenshots/GIFs for UI changes
    - Any manual testing you performed
+8. **Add translations** for any new user-visible string. Nine languages ship
+   alongside English in `web/src/locales/`, and a missing key renders its
+   English source rather than failing — so an untranslated string is invisible
+   until somebody reading that language finds it. `npm run i18n:check` and
+   `node scripts/i18n-catalog-check.mjs` report where you stand; the catalogue
+   key for a plural is the `other` form. See [CLAUDE.md](CLAUDE.md).
+
+`main` is protected. A change reaches it through a pull request whose **build**
+check has passed — not afterwards — and the branch cannot be force-pushed or
+deleted. No approving review is required, so a PR of your own is not blocked
+waiting for one.
 
 ### Code Style
 


### PR DESCRIPTION
Two things a contributor could otherwise only find by tripping over them — and the first of them is new as of today.

**`main` is protected.** A ruleset now requires a pull request whose `build` check has passed *before* the merge, and blocks force-push and deletion. No approving review is required, and deliberately so: requiring one would lock a solo maintainer out of their own repository rather than protect anything.

**A new user-visible string is work in nine catalogues.** A missing key renders its English source instead of failing, so the omission is invisible from here and immediately obvious to anyone reading that language. Points at the checks, and at `CLAUDE.md` for the plural-key trap rather than repeating it.

Docs only — no code, no strings, no catalogue changes.

Doubling as the first PR under the new ruleset, to confirm the `build` context resolves and the merge is not held for an approval nobody can give.