### PR TITLE
Say near the top that latest lags main, and by how long

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ durable belongs to Stalwart; the container is disposable.
 | 🧪 **[KNOWN-ISSUES.md](KNOWN-ISSUES.md)** | What was verified live, and where Stalwart departs from a spec |
 | 🛣 **[ROADMAP.md](ROADMAP.md)** | What ihasmail does not do, and why |
 
+> **Releases are weekly, so `latest` normally lags `main`.** Automation builds
+> and publishes the GHCR image every **Monday at 09:00 UTC**, in a week that had
+> changes. Between one Monday and the next, `main` is ahead of the newest image
+> — a fix merged on Tuesday is a `docker pull` away only after the following
+> Monday. GitHub runs scheduled workflows on a best-effort basis, so treat the
+> hour as approximate.
+>
+> This is worth knowing when a closed issue says a fix is *live*: that means the
+> QA webmail server, which deploys from `main`, and not the image you have. If
+> you want a change before the next Monday, build from `main` — see
+> [Container images](#container-images). Otherwise pull after it, and the dated
+> tag tells you exactly which build you are on.
+
 This file is for people working *on* ihasmail. Everything about running it
 lives in the docs.
 
@@ -96,7 +109,9 @@ Full instructions, TLS, and every environment variable:
 
 ### Container images
 
-Published to GHCR on every release, for `linux/amd64` and `linux/arm64`:
+Published to GHCR on every release, for `linux/amd64` and `linux/arm64`.
+Releases are cut weekly — Mondays, 09:00 UTC, in a week that had changes — so
+the newest image is normally behind `main`:
 
 ```bash
 docker pull ghcr.io/coffey-labs/ihasmail:latest


### PR DESCRIPTION
A fix announced as "live" on a closed issue means **ihasmail.com**, which deploys from `main`. It does not mean the image anybody has pulled — that is cut weekly, Mondays at 09:00 UTC, so between one Monday and the next `main` runs ahead of the newest release by up to a week.

That distinction was written down nowhere, and it confused the reporter on #174 this week. My wording caused it: three comments invited him to try changes that were merged and not yet published.

**Placement.** Above the "this file is for people working *on* ihasmail" line, rather than under **Container images**. The person who needs this is reading to decide whether to pull; by the time they reach that section they usually have. Container images gains the cadence as well, since "Published to GHCR on every release" says nothing about how often a release happens.

The hour is given as approximate deliberately — GitHub runs scheduled workflows best-effort and delays them when its queue is busy, which the release workflow's own comment already notes.

Docs only — no code, no strings, no catalogue changes.