### PR TITLE
Add GitHub Sponsors funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# Funding platforms shown behind the repository's Sponsor button.
+# https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+
+github: LINUXexpert-org


### PR DESCRIPTION
Adds `.github/FUNDING.yml` so the repository shows a **Sponsor** button linking to the existing public GitHub Sponsors listing for `LINUXexpert-org` (live, tiers at $5/mo, $5 one-time, $25/mo, with a $100/month goal).

Only the `github:` platform is set — no other funding platforms are in use.