### PR TITLE
Compress the bundle in the nginx example

### DIFF
--- a/nginx.example.conf
+++ b/nginx.example.conf
@@ -6,6 +6,26 @@ server {
 
     client_max_body_size 60m;
 
+    # ihasmail serves its bundle uncompressed and leaves this to the proxy, so
+    # without these directives the browser downloads about 915 KB where 307 KB
+    # would do. text/event-stream is deliberately absent from gzip_types: the
+    # push stream must not be compressed or buffered.
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 5;
+    gzip_min_length 1024;
+    # ihasmail serves scripts as text/javascript, so listing only
+    # application/javascript silently leaves the largest asset uncompressed.
+    gzip_types
+        application/javascript
+        application/json
+        application/manifest+json
+        image/svg+xml
+        text/css
+        text/javascript
+        text/plain;
+
     location / {
         proxy_pass http://127.0.0.1:8080;
         proxy_http_version 1.1;


### PR DESCRIPTION
The Caddy example has `encode zstd gzip`. The nginx example had no compression
directive at all, so anyone following it served every asset uncompressed.

Measured against the built app, through nginx in front of the real container:

| | Wire | Decoded |
| --- | --- | --- |
| before | 915,199 B | 915,199 B |
| after | **322,873 B** | 915,199 B |

2.8x less on first load, and the gap was invisible without inspecting response
headers.

### Two things worth a second look in review

**`text/javascript` is listed explicitly.** The server sends scripts with that
type, not `application/javascript`. A conventional gzip_types list compresses
the stylesheet and leaves the 647 KB script uncompressed — which is exactly
what the first attempt at this change did, and it looked like it was working.

**`text/event-stream` is deliberately absent.** Compressing or buffering the
push stream would break it; `proxy_buffering off` is already set below for the
same reason.

### Verified

Ran nginx with this config in front of the container:

- `/assets/*.js` returns `Content-Encoding: gzip` with `Vary: Accept-Encoding`
- `/api/events` still returns `text/event-stream` with no `Content-Encoding`,
  and delivered a real `StateChange` event as plain text while messages were
  being delivered to the account
- sign-in through the proxy unaffected

Docs only — no application code changes.