### PR TITLE
Stop naming every palette in the credit line

### DIFF
--- a/web/src/locales/de.ts
+++ b/web/src/locales/de.ts
@@ -1155,7 +1155,7 @@ export const catalog: Catalog = {
     "Counts people rather than headers, so one address in To and nine in Cc is a message to ten. Catches a reply-all onto a long thread.": "Zählt Personen statt Kopfzeilen: eine Adresse in An und neun in Cc ergeben eine Nachricht an zehn. Erfasst ein Allen-Antworten auf einen langen Thread.",
     "Date received": "Empfangsdatum",
     "Date sent": "Sendedatum",
-    "Dracula, Gruvbox, Rosé Pine and Tokyo Night are the work of their own projects and are used under the MIT licence; the shades between their published colours are derived, and every one of them is checked for contrast. The accent colour below still applies over any of them.": "Dracula, Gruvbox, Rosé Pine und Tokyo Night sind das Werk ihrer eigenen Projekte und werden unter der MIT-Lizenz verwendet; die Abstufungen zwischen ihren veröffentlichten Farben sind davon abgeleitet, und jede einzelne wird auf Kontrast geprüft. Die Akzentfarbe unten gilt weiterhin über jeder von ihnen.",
+    "Palettes named after another project are that project's work, used under its own licence; the shades between their published colours are derived, and every one is checked for contrast. The accent colour below still applies over any of them.": "Paletten, die nach einem anderen Projekt benannt sind, stammen von diesem Projekt und werden unter dessen eigener Lizenz verwendet; die Abstufungen zwischen den veröffentlichten Farben sind abgeleitet, und jede davon wird auf Kontrast geprüft. Die Akzentfarbe unten gilt weiterhin über jeder von ihnen.",
     "Earlier": "Früher",
     "Every folder": "Jeder Ordner",
     "Everyone addressed will receive this.": "Alle Adressierten erhalten dies.",

--- a/web/src/locales/es.ts
+++ b/web/src/locales/es.ts
@@ -1111,7 +1111,7 @@ export const catalog: Catalog = {
     "Date received": "Fecha de recepción",
     "Date sent": "Fecha de envío",
     "Day view": "Vista de día",
-    "Dracula, Gruvbox, Rosé Pine and Tokyo Night are the work of their own projects and are used under the MIT licence; the shades between their published colours are derived, and every one of them is checked for contrast. The accent colour below still applies over any of them.": "Dracula, Gruvbox, Rosé Pine y Tokyo Night son obra de sus propios proyectos y se usan bajo la licencia MIT; los tonos intermedios entre sus colores publicados son derivados, y todos se comprueban en cuanto a contraste. El color de acento de abajo sigue aplicándose sobre cualquiera de ellos.",
+    "Palettes named after another project are that project's work, used under its own licence; the shades between their published colours are derived, and every one is checked for contrast. The accent colour below still applies over any of them.": "Las paletas que llevan el nombre de otro proyecto son obra de ese proyecto y se usan bajo su propia licencia; los tonos intermedios entre sus colores publicados son derivados, y cada uno se comprueba para el contraste. El color de acento de abajo sigue aplicándose sobre cualquiera de ellas.",
     "Earlier": "Antes",
     "Every folder": "Todas las carpetas",
     "Everyone addressed will receive this.": "Todos los destinatarios lo recibirán.",

--- a/web/src/locales/fr.ts
+++ b/web/src/locales/fr.ts
@@ -1116,7 +1116,7 @@ export const catalog: Catalog = {
     "Date received": "Date de réception",
     "Date sent": "Date d'envoi",
     "Day view": "Vue jour",
-    "Dracula, Gruvbox, Rosé Pine and Tokyo Night are the work of their own projects and are used under the MIT licence; the shades between their published colours are derived, and every one of them is checked for contrast. The accent colour below still applies over any of them.": "Dracula, Gruvbox, Rosé Pine et Tokyo Night sont l'œuvre de leurs propres projets et sont utilisés sous licence MIT ; les nuances entre leurs couleurs publiées en sont dérivées, et chacune est vérifiée pour le contraste. La couleur d'accent ci-dessous s'applique toujours par-dessus n'importe laquelle d'entre elles.",
+    "Palettes named after another project are that project's work, used under its own licence; the shades between their published colours are derived, and every one is checked for contrast. The accent colour below still applies over any of them.": "Les palettes portant le nom d'un autre projet sont l'œuvre de ce projet et sont utilisées sous sa propre licence ; les nuances intermédiaires entre leurs couleurs publiées sont dérivées, et chacune est vérifiée pour le contraste. La couleur d'accentuation ci-dessous s'applique toujours par-dessus n'importe laquelle d'entre elles.",
     "Earlier": "Plus tôt",
     "Every folder": "Tous les dossiers",
     "Everyone addressed will receive this.": "Tous les destinataires le recevront.",

--- a/web/src/locales/ja.ts
+++ b/web/src/locales/ja.ts
@@ -1119,7 +1119,7 @@ export const catalog: Catalog = {
     "Date received": "受信日時",
     "Date sent": "送信日時",
     "Day view": "日表示",
-    "Dracula, Gruvbox, Rosé Pine and Tokyo Night are the work of their own projects and are used under the MIT licence; the shades between their published colours are derived, and every one of them is checked for contrast. The accent colour below still applies over any of them.": "Dracula、Gruvbox、Rosé Pine、Tokyo Night はそれぞれのプロジェクトの成果物で、MIT ライセンスのもとで利用しています。公開された色の中間の階調は派生させたもので、いずれもコントラストを確認しています。下のアクセントカラーはどの配色の上にも適用されます。",
+    "Palettes named after another project are that project's work, used under its own licence; the shades between their published colours are derived, and every one is checked for contrast. The accent colour below still applies over any of them.": "他のプロジェクトの名前が付いたパレットは、そのプロジェクトの成果物であり、そのプロジェクト自身のライセンスのもとで使用しています。公開されている色の中間の階調は派生させたもので、いずれもコントラストを検証しています。下のアクセントカラーは、どのパレットの上にも適用されます。",
     "Earlier": "これより前",
     "Every folder": "すべてのフォルダー",
     "Everyone addressed will receive this.": "宛先の全員がこれを受け取ります。",

--- a/web/src/locales/nl.ts
+++ b/web/src/locales/nl.ts
@@ -1107,7 +1107,7 @@ export const catalog: Catalog = {
     "Date received": "Ontvangstdatum",
     "Date sent": "Verzenddatum",
     "Day view": "Dagweergave",
-    "Dracula, Gruvbox, Rosé Pine and Tokyo Night are the work of their own projects and are used under the MIT licence; the shades between their published colours are derived, and every one of them is checked for contrast. The accent colour below still applies over any of them.": "Dracula, Gruvbox, Rosé Pine en Tokyo Night zijn het werk van hun eigen projecten en worden gebruikt onder de MIT-licentie; de tinten tussen hun gepubliceerde kleuren zijn daarvan afgeleid, en elk daarvan wordt op contrast gecontroleerd. De accentkleur hieronder geldt nog steeds over elk ervan.",
+    "Palettes named after another project are that project's work, used under its own licence; the shades between their published colours are derived, and every one is checked for contrast. The accent colour below still applies over any of them.": "Paletten die naar een ander project zijn genoemd, zijn het werk van dat project en worden gebruikt onder de eigen licentie daarvan; de tinten tussen de gepubliceerde kleuren zijn afgeleid en elk daarvan wordt op contrast gecontroleerd. De accentkleur hieronder geldt nog steeds over elk ervan.",
     "Earlier": "Eerder",
     "Every folder": "Elke map",
     "Everyone addressed will receive this.": "Iedereen die is geadresseerd ontvangt dit.",

--- a/web/src/locales/pt-BR.ts
+++ b/web/src/locales/pt-BR.ts
@@ -1114,7 +1114,7 @@ export const catalog: Catalog = {
     "Date received": "Data de recebimento",
     "Date sent": "Data de envio",
     "Day view": "Visualização de dia",
-    "Dracula, Gruvbox, Rosé Pine and Tokyo Night are the work of their own projects and are used under the MIT licence; the shades between their published colours are derived, and every one of them is checked for contrast. The accent colour below still applies over any of them.": "Dracula, Gruvbox, Rosé Pine e Tokyo Night são obra dos seus próprios projetos e são usados sob a licença MIT; os tons entre as cores publicadas por eles são derivados, e cada um deles é verificado quanto ao contraste. A cor de destaque abaixo continua se aplicando sobre qualquer um deles.",
+    "Palettes named after another project are that project's work, used under its own licence; the shades between their published colours are derived, and every one is checked for contrast. The accent colour below still applies over any of them.": "As paletas que levam o nome de outro projeto são obra desse projeto e são usadas sob a licença dele; os tons entre as cores publicadas são derivados, e cada um é verificado quanto ao contraste. A cor de destaque abaixo continua se aplicando sobre qualquer uma delas.",
     "Earlier": "Antes",
     "Every folder": "Todas as pastas",
     "Everyone addressed will receive this.": "Todos os destinatários receberão isto.",

--- a/web/src/locales/ru.ts
+++ b/web/src/locales/ru.ts
@@ -1113,7 +1113,7 @@ export const catalog: Catalog = {
     "Date received": "Дата получения",
     "Date sent": "Дата отправки",
     "Day view": "День",
-    "Dracula, Gruvbox, Rosé Pine and Tokyo Night are the work of their own projects and are used under the MIT licence; the shades between their published colours are derived, and every one of them is checked for contrast. The accent colour below still applies over any of them.": "Dracula, Gruvbox, Rosé Pine и Tokyo Night созданы своими проектами и используются по лицензии MIT; оттенки между опубликованными цветами выведены из них, и каждый проверен на контраст. Акцентный цвет ниже по-прежнему применяется поверх любой из тем.",
+    "Palettes named after another project are that project's work, used under its own licence; the shades between their published colours are derived, and every one is checked for contrast. The accent colour below still applies over any of them.": "Палитры, названные в честь другого проекта, созданы этим проектом и используются по его собственной лицензии; оттенки между опубликованными цветами выводятся расчётом, и каждый из них проверяется на контраст. Акцентный цвет ниже по-прежнему применяется поверх любой из них.",
     "Earlier": "Раньше",
     "Every folder": "Все папки",
     "Everyone addressed will receive this.": "Это получат все указанные адресаты.",

--- a/web/src/locales/uk.ts
+++ b/web/src/locales/uk.ts
@@ -1107,7 +1107,7 @@ export const catalog: Catalog = {
     "Date received": "Дата отримання",
     "Date sent": "Дата надсилання",
     "Day view": "День",
-    "Dracula, Gruvbox, Rosé Pine and Tokyo Night are the work of their own projects and are used under the MIT licence; the shades between their published colours are derived, and every one of them is checked for contrast. The accent colour below still applies over any of them.": "Dracula, Gruvbox, Rosé Pine і Tokyo Night створені власними проєктами й використовуються за ліцензією MIT; відтінки між опублікованими кольорами виведені з них, і кожен перевірено на контраст. Акцентний колір нижче й далі застосовується поверх будь-якої з тем.",
+    "Palettes named after another project are that project's work, used under its own licence; the shades between their published colours are derived, and every one is checked for contrast. The accent colour below still applies over any of them.": "Палітри, названі на честь іншого проєкту, є роботою цього проєкту й використовуються за його власною ліцензією; відтінки між опублікованими кольорами обчислюються, і кожен із них перевіряється на контраст. Акцентний колір нижче й надалі застосовується поверх будь-якої з них.",
     "Earlier": "Раніше",
     "Every folder": "Усі теки",
     "Everyone addressed will receive this.": "Це отримають усі зазначені адресати.",

--- a/web/src/locales/zh-Hans.ts
+++ b/web/src/locales/zh-Hans.ts
@@ -1118,7 +1118,7 @@ export const catalog: Catalog = {
     "Date received": "接收日期",
     "Date sent": "发送日期",
     "Day view": "日视图",
-    "Dracula, Gruvbox, Rosé Pine and Tokyo Night are the work of their own projects and are used under the MIT licence; the shades between their published colours are derived, and every one of them is checked for contrast. The accent colour below still applies over any of them.": "Dracula、Gruvbox、Rosé Pine 和 Tokyo Night 均由各自的项目创作，依 MIT 许可证使用；其公布配色之间的过渡色为衍生所得，且每一种都经过对比度检查。下方的强调色仍会应用于其中任意一种之上。",
+    "Palettes named after another project are that project's work, used under its own licence; the shades between their published colours are derived, and every one is checked for contrast. The accent colour below still applies over any of them.": "以其他项目命名的配色方案是该项目的作品，按其自身的许可证使用；已发布颜色之间的过渡色是推导得出的，并且每一种都经过对比度检查。下方的强调色仍会应用于其中任何一种配色方案。",
     "Earlier": "更早",
     "Every folder": "所有文件夹",
     "Everyone addressed will receive this.": "所有收件人都会收到此邮件。",

--- a/web/src/views/settings/AppearanceSettings.tsx
+++ b/web/src/views/settings/AppearanceSettings.tsx
@@ -83,7 +83,7 @@ export function AppearanceSettings() {
         })}
       </div>
       <p className="hint" style={{ marginTop: 10 }}>
-        {translate("Dracula, Gruvbox, Rosé Pine and Tokyo Night are the work of their own projects and are used under the MIT licence; the shades between their published colours are derived, and every one of them is checked for contrast. The accent colour below still applies over any of them.")}
+        {translate("Palettes named after another project are that project's work, used under its own licence; the shades between their published colours are derived, and every one is checked for contrast. The accent colour below still applies over any of them.")}
       </p>
       <Switch
         checked={s.themeMessageBody}


### PR DESCRIPTION
Groundwork for adding more palettes.

The hint under the theme picker named the four third-party palettes in a sentence that is translated into nine languages. Adding a palette therefore meant rewriting that sentence, retranslating it nine times, and leaving the old version behind as a stale key that nothing ever looks up. The catalogue checker already reports 41 such keys, and this was on course to add nine more per palette.

It now states the rule rather than listing the cases: a palette named after another project is that project's work, used under its own licence. That is true of the four here, true of the next one, and true without asserting "MIT" for a palette that might carry a different permissive licence. The names have not gone anywhere. They sit beside each swatch in Settings and in NOTICE with their copyright lines, which is where a credit belongs.

The string was **swapped** in all nine catalogues rather than added alongside the old one, so nothing is left stale. Per-locale coverage is unchanged at 1,255 of 1,279, no locale gained a fallback to English, and the 41 pre-existing stale keys are neither added to nor cleaned up here.

1104 web tests pass; typecheck clean.