### PR TITLE
Take hono to 4.13.7 and let Dependabot open the next one

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+version: 2
+updates:
+  # The npm entry sits at the root because that is where the single lockfile
+  # is: root, server and web are one npm workspace, so one entry covers all
+  # three. Pointing entries at server/ or web/ would find package.json files
+  # with no lockfile beside them and update nothing.
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "09:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      # Everything routine arrives as one PR a week, so the dashboard is not
+      # the only place these get noticed. Majors are deliberately left out of
+      # the group: they are migrations, not bumps -- vitest 3 to 4 is one --
+      # and each deserves its own PR and its own CI run.
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "09:00"
+      timezone: Etc/UTC
+    groups:
+      actions:
+        patterns:
+          - "*"
+  # The runtime and build stages both pin node:22-alpine, so this is what
+  # keeps the published container images off a stale base between the weekly
+  # releases.
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "09:00"
+      timezone: Etc/UTC

--- a/package-lock.json
+++ b/package-lock.json
@@ -2133,9 +2133,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.13.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
-      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3830,7 +3830,7 @@
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@hono/node-server": "^1.13.8",
-        "hono": "^4.7.4"
+        "hono": "^4.13.7"
       },
       "devDependencies": {
         "@types/node": "^22.13.10",

--- a/server/package.json
+++ b/server/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.13.8",
-    "hono": "^4.7.4"
+    "hono": "^4.13.7"
   },
   "devDependencies": {
     "@types/node": "^22.13.10",


### PR DESCRIPTION
Closes three of the five open Dependabot alerts, and sets up the config that should have surfaced them as PRs in the first place.

## hono 4.13.3 → 4.13.7

Three medium advisories, all fixed in 4.13.5:

| GHSA | Issue | Exposure here |
|---|---|---|
| `gqvv-2mrq-wpjv` | `toSSG()` writes files outside the output directory | None — `toSSG` is never called |
| `crvj-82cr-hjcx` | Query parser reads parameters after the URL fragment, causing cache-key and proxy interpretation differentials | Low — `c.req.query()` is read in `imageproxy.ts`, `icsproxy.ts` and `app.ts`, but `safeFetch` validates the value it actually fetches rather than a separate pre-check, so there is nothing to desync |
| `g6gw-c38x-mqfc` | Unbounded dot-notation nesting in `parseBody()` can exhaust memory | None — `parseBody` is never called |

A patch release with no API change, so it is worth taking regardless of how little of it we are exposed to. The declared range moves from `^4.7.4` to `^4.13.7` as well, so the security floor is recorded in `server/package.json` and not only in the lockfile.

## dependabot.yml

There was no config at all, which is why nothing opened a PR and the alerts sat on the dashboard until someone went looking. One npm entry at the root covers server and web, since they share a single lockfile as one workspace; github-actions and docker entries keep the pinned `node:22-alpine` base and the action versions moving between weekly releases.

Routine minor and patch updates group into one PR a week. Majors are left out of the group on purpose — they are migrations rather than bumps, and each should carry its own CI run.

## Still open after this

Alerts 4 and 5, `GHSA-82fw-gwwq-j7x9` — path traversal in `@vitest/mocker`. There is no fix in the 3.x line: patched versions are 4.1.11 and 5.0.0-rc.2 only, so clearing them is a major bump from 3.2.7 across 133 test files in `web`. Server tests use `tsx --test` and are unaffected. Dev-only exposure, no browser mode configured. Worth its own PR.

## Verification

`npm run typecheck`, `npm test` (168 server tests plus the web suite) and `npm run build` all pass locally.