### PR TITLE
Point the @ alias at a relative path, and drop baseUrl

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -16,8 +16,7 @@
     "allowImportingTsExtensions": true,
     "noEmit": true,
     "types": ["vite/client"],
-    "baseUrl": ".",
-    "paths": { "@/*": ["src/*"] }
+    "paths": { "@/*": ["./src/*"] }
   },
   "include": ["src", "vite.config.ts"]
 }


### PR DESCRIPTION
Prerequisite for #318 (`typescript` 5.9.3 → 7.0.2), which currently fails CI.

## What was blocking it

TypeScript 7 removes `baseUrl` and no longer accepts a non-relative entry in `paths`, so #318 never got as far as our source:

```
tsconfig.json(19,5): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
tsconfig.json(20,24): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
```

A leading `./` expresses the same mapping without `baseUrl` — `paths` entries resolve against the tsconfig's own directory, which is exactly what `baseUrl: "."` was arranging.

## This does not wait for the upgrade

Relative `paths` without a `baseUrl` has been the supported spelling since TypeScript 4.4, so this typechecks identically under the 5.9.3 we ship today. Vite resolves `@` through its own `resolve.alias` in `vite.config.ts` and never consulted this setting, so the build is unaffected.

## The upgrade is clear behind it

I checked rather than assumed the two reported errors were the whole story: with this change applied, TypeScript **7.0.2 typechecks both workspaces clean** — `web` and `server`, exit 0 on each. `server/tsconfig.json` needed nothing; it has neither setting.

So #318 should go green on a rebase, with no further work.

## Verification

`npm run typecheck` (5.9.3), `npm test` (1153 web tests, 168 server tests) and `npm run build` all pass. Typechecked separately against 7.0.2 as described above.