### PR TITLE
Move CI, the image and the Node types to 26 together

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 26
           cache: npm
       - run: npm ci --ignore-scripts
       - run: npm run typecheck

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,7 +82,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 26
       - id: v
         run: |
           V="$(node scripts/version.mjs)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 26
       - id: decide
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ---- build stage ----
-FROM node:22-alpine AS build
+FROM node:26-alpine AS build
 # What this build calls itself: 2.16.<PR>, worked out by whoever runs the
 # build. It cannot be worked out in here -- .dockerignore keeps .git out of the
 # context on purpose, and git is not installed either. `node scripts/version.mjs`
@@ -25,7 +25,7 @@ COPY . .
 RUN npm run build
 
 # ---- runtime stage ----
-FROM node:22-alpine AS runtime
+FROM node:26-alpine AS runtime
 # Re-declared: an ARG does not cross stages.
 ARG IHASMAIL_VERSION=""
 ARG BASE_PATH=""

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ missing.
 
 ## Development
 
-Requirements: Node ≥ 20.19 (22 recommended), npm ≥ 10.
+Requirements: Node ≥ 20.19 (26 recommended), npm ≥ 10.
 
 ```bash
 npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -968,13 +968,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.20.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.2.tgz",
-      "integrity": "sha512-xlvWf4Vs9n1PEVYwP1n4vvG07M6y8WgvJ2t0vbrWTmijsIHp1cS+uJ2kMIRdY3nHZK0nCYKrPeD171+SzF4/zw==",
+      "version": "26.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.5.1.tgz",
+      "integrity": "sha512-CzNm2FezW4VR/LjG6yUdiEgLE/rAQ9Slj5gCu/C2VrdcW7I0ahNZ8DRbHT7zOZ6r3ONgd/bsQIeSaoDGrd1C6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~8.9.0"
       }
     },
     "node_modules/@types/react": {
@@ -2778,9 +2778,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.9.0.tgz",
+      "integrity": "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3186,7 +3186,7 @@
         "hono": "^4.13.7"
       },
       "devDependencies": {
-        "@types/node": "^22.13.10",
+        "@types/node": "^26.5.1",
         "tsx": "^4.23.13",
         "typescript": "^7.0.2"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,7 @@
     "hono": "^4.13.7"
   },
   "devDependencies": {
-    "@types/node": "^22.13.10",
+    "@types/node": "^26.5.1",
     "tsx": "^4.23.13",
     "typescript": "^7.0.2"
   }


### PR DESCRIPTION
Supersedes #313 (`node:22-alpine` → `26-alpine`) and #315 (`@types/node` → 26), which cannot safely land separately.

## Why one change

Four places describe the Node version, and moving any one alone leaves the build somewhere the others are not:

| | was | now |
|---|---|---|
| `.github/workflows/ci.yml` | 22 | 26 |
| `.github/workflows/publish.yml` | 22 | 26 |
| `.github/workflows/release.yml` | 22 | 26 |
| `Dockerfile` (build + runtime stages) | `node:22-alpine` | `node:26-alpine` |
| `server` `@types/node` | `^22.13.10` | `^26.5.1` |

#315 alone would typecheck against APIs the runtime does not have. #313 alone would ship a major that CI never exercised. Together they are coherent.

## Read this before deploying it

**Node 26 is Current, not LTS.** I checked the images rather than assuming:

```
node:26-alpine -> v26.8.2  lts=none
node:24-alpine -> v24.21.0 lts=Krypton
node:22-alpine -> v22.23.2 lts=Jod
```

So this moves the published image off an LTS line onto Current. Node 26 is due to become Active LTS in October 2026, about a month out, and nothing in ihasmail needs 26 over 24 — **if the LTS line is preferred, every pin here is a single number and I will happily redo it as 24.** Dependabot proposed 26 because it tracks latest, not because anything required it.

`engines` stays at `>=20.19`. That field is the floor for *running* ihasmail, not the version we build it on, and self-hosters on 20 or 22 are unaffected by this. The README's "recommended" figure follows CI to 26.

## Verified on the runtime, not just in CI

- `npm run typecheck` passes against the Node 26 types.
- `npm test` — 1153 web tests across 113 files, 168 server tests.
- `npm run build` passes.
- `docker build` on `node:26-alpine` succeeds locally; the resulting image reports `v26.8.2`, starts, and answers `/api/health` with `{"ok":true,...}`.
- The login, SSE (`/api/events`) and body-carrying `POST /api/jmap` checks from #323 all pass against a server running on Node 26.8.1.