### PR TITLE
Point the Sponsor button at the current GitHub username

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,4 @@
 # Funding platforms shown behind the repository's Sponsor button.
 # https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
 
-github: LINUXexpert-org
+github: jcoffey-dev


### PR DESCRIPTION
The account behind the Sponsor button was renamed from `LINUXexpert-org` to `jcoffey-dev`, and GitHub does not redirect the old name:

```
github.com/sponsors/LINUXexpert-org -> 404
github.com/sponsors/jcoffey-dev     -> 200
```

`api/users/LINUXexpert-org` 404s too. So this repository's Sponsor button has been leading nowhere since the rename.

Worth changing rather than trusting a redirect that does not exist: a released username can be registered by anyone, at which point a stale link stops being a dead end and starts being someone else's page.

One line. Nothing else in this repository referenced the old username — I swept case-insensitively.