### PR TITLE
Render plain-text mail with its line breaks

### DIFF
--- a/web/src/lib/__tests__/htmlAlternative.test.ts
+++ b/web/src/lib/__tests__/htmlAlternative.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { hasHtmlAlternative } from "../html";
+
+/*
+ * The rule: `htmlBody` is derived, so its presence proves nothing. Only the
+ * part's own type says whether there is an HTML alternative to render.
+ *
+ * The shapes below are what Stalwart 0.16.21 actually returned for one thread
+ * on 2026-09-10, read back through `Email/get` with
+ * `bodyProperties: ["partId", "type"]`. A plain-text message named the *same*
+ * part in both lists; a message with a real alternative named two.
+ *
+ * Getting this wrong is not a rendering nicety. Plain text went to the HTML
+ * path, which places the body under `white-space: normal`, so every line break
+ * collapsed: hard-wrapped mail arrived as one paragraph, and the signature and
+ * the quoted reply ran into the prose.
+ */
+describe("deciding whether a message has an HTML alternative", () => {
+  it("says no to a plain-text message, whose htmlBody holds the text part", () => {
+    // As returned for mo@bunkus.online: htmlBody[0] and textBody[0] are the
+    // same part, typed text/plain.
+    expect(hasHtmlAlternative({ type: "text/plain" }, "Hey,\n\nmy earlier response was before\n")).toBe(false);
+  });
+
+  it("says yes to a real multipart/alternative", () => {
+    expect(hasHtmlAlternative({ type: "text/html" }, "<p>Hello</p>")).toBe(true);
+  });
+
+  it("keeps the parameters that follow a media type", () => {
+    // `type` arrives bare in practice, but a charset must not turn a real HTML
+    // part into a plain-text one.
+    expect(hasHtmlAlternative({ type: "text/html; charset=utf-8" }, "<p>Hi</p>")).toBe(true);
+  });
+
+  it("is not fooled by a type that merely starts with the right letters", () => {
+    expect(hasHtmlAlternative({ type: "text/htmlish" }, "<p>Hi</p>")).toBe(false);
+  });
+
+  it("matches the type case-insensitively, since a header may be capitalised", () => {
+    expect(hasHtmlAlternative({ type: "TEXT/HTML" }, "<p>Hi</p>")).toBe(true);
+  });
+
+  it("says no when the part is HTML but its value never arrived", () => {
+    // maxBodyValueBytes can leave a part named with nothing fetched; falling
+    // through to the text body is the useful answer, not an empty pane.
+    expect(hasHtmlAlternative({ type: "text/html" }, undefined)).toBe(false);
+    expect(hasHtmlAlternative({ type: "text/html" }, "")).toBe(false);
+  });
+
+  it("says no when there is no part at all", () => {
+    expect(hasHtmlAlternative(undefined, undefined)).toBe(false);
+    expect(hasHtmlAlternative({}, "something")).toBe(false);
+  });
+});

--- a/web/src/lib/html.ts
+++ b/web/src/lib/html.ts
@@ -350,6 +350,26 @@ export function markKeptSurfaces(root: ParentNode): number {
   return kept;
 }
 
+/**
+ * Whether a message really has an HTML alternative to render.
+ *
+ * `htmlBody` is a *derived* list, not a filter: RFC 8621 §4.1.4 says a message
+ * with no HTML alternative still gets one, and it holds the text/plain part.
+ * Confirmed live against Stalwart 0.16.21 (2026-09-10) -- a plain-text mail
+ * comes back with `htmlBody` and `textBody` naming the same part, typed
+ * `text/plain`, while a real multipart/alternative names two different parts.
+ *
+ * So "is there a body value under htmlBody" is not the question; the part's own
+ * type is. Answering the first one sent every plain-text message down the HTML
+ * path, where the body is placed in `.ihm-email-root` under
+ * `white-space: normal` and every line break collapses -- hard-wrapped mail
+ * arrived as a single paragraph with the signature and the quoted reply run
+ * into the prose.
+ */
+export function hasHtmlAlternative(part: { type?: string } | undefined, value: string | undefined): boolean {
+  return /^text\/html\b/i.test(part?.type ?? "") && Boolean(value);
+}
+
 export const TEXT_EMAIL_CSS = `
 :host { display:block; }
 .ihm-text-root { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace; font-size: 13.5px; line-height:1.55; white-space: pre-wrap; overflow-wrap: anywhere; color: inherit; }

--- a/web/src/views/mail/MessageView.tsx
+++ b/web/src/views/mail/MessageView.tsx
@@ -18,7 +18,7 @@ import { internalDomains, isExternalSender, linkVerdict } from "@/lib/warnings";
 import { spamReport, type SpamReport } from "@/lib/spamScore";
 import { formatFullDate, formatListDate, formatSize } from "@/lib/format";
 import { displayName, domainOf, formatAddress } from "@/lib/address";
-import { EMAIL_BASE_CSS, TEXT_EMAIL_CSS, htmlDeclaresColors, markKeptSurfaces, sanitizeEmailHtml } from "@/lib/html";
+import { EMAIL_BASE_CSS, TEXT_EMAIL_CSS, hasHtmlAlternative, htmlDeclaresColors, markKeptSurfaces, sanitizeEmailHtml } from "@/lib/html";
 import { openableInTab, previewKind } from "@/lib/preview";
 import { FilePreviewDialog } from "@/ui/filepreview";
 import { findQuoteStart, htmlToText, textToHtml } from "@/lib/text";
@@ -137,7 +137,9 @@ export const MessageView = memo(function MessageView({ email: e, expanded, wasUn
   const textPart = e.textBody?.[0];
   const htmlRaw = htmlPart?.partId ? e.bodyValues?.[htmlPart.partId]?.value : undefined;
   const textRaw = textPart?.partId ? e.bodyValues?.[textPart.partId]?.value : undefined;
-  const showHtml = Boolean(htmlRaw);
+  // Not `Boolean(htmlRaw)`: `htmlBody` carries the text part when there is no
+  // HTML alternative. See hasHtmlAlternative().
+  const showHtml = hasHtmlAlternative(htmlPart, htmlRaw);
   const themeMessageBody = settings.themeMessageBody;
   const themeStyledMessages = settings.themeStyledMessages;
 


### PR DESCRIPTION
Every plain-text message has been rendering as one continuous paragraph — line breaks collapsed, signature and quoted reply run into the prose. Reported from the inbox; reproduced and diagnosed against the live instance.

## Cause

`MessageView` decided which renderer to use with `showHtml = Boolean(htmlRaw)`.

But `htmlBody` is a **derived list, not a filter**. RFC 8621 §4.1.4 gives a message with no HTML alternative one anyway, holding the `text/plain` part. So `htmlRaw` is populated for plain-text mail, `showHtml` went true, and the message was routed to `HtmlBody` → `.ihm-email-root`, which is `white-space: normal`. Every newline collapsed.

Confirmed live against Stalwart 0.16.21 on 2026-09-10, reading the same thread back through `Email/get` with `bodyProperties: ["partId", "type"]`:

| from | `htmlBody` | `textBody` | same part |
|---|---|---|---|
| plain-text sender | `["text/plain"]` | `["text/plain"]` | **yes** |
| real alternative | `["text/html"]` | `["text/plain"]` | no |

The distinction was cleanly available — `type` was already in `BODY_PROPS`, and nothing looked at it.

## Fix

Ask what the part actually is, not whether a value came back. The decision moves into `hasHtmlAlternative()` in `lib/html.ts` so it can be tested and so the reasoning has somewhere to live.

`TextBody` was written for exactly these messages and was simply unreachable. So this also switches on everything it does and that has never fired on plain-text mail:

- `white-space: pre-wrap` — the line breaks the sender wrote
- quote-depth colouring (`.q1`/`.q2`/`.q3`)
- the collapsible `•••` quoted block

## Scope

Affects every plain-text-only message — mailing lists, `git send-email`, most automated notification mail. Not a corner case.

No user-facing strings added or changed, so **no translation work**; the nine catalogues are untouched.

## Checks

- `npm run typecheck` — clean, both packages
- `npm test` — 1160 web tests / 114 files, 168 server tests, all passing
- `npm run build` — clean
- 7 new tests pinning the rule, built from the part shapes the live server actually returned

## Not included

After this, hard-wrapped mail sets its own measure through the sender's line breaks and reads correctly. Mail with very long unwrapped lines will run the full width of the reading pane; a `max-width` in `ch` on `.ihm-text-root` would cap that, but it is a separate judgement about typography rather than a bug, so it is left out.