### PR TITLE
Give the i18n scripts a parser again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
       ],
       "devDependencies": {
         "concurrently": "^9.1.2",
-        "typescript": "^7.0.2"
+        "typescript": "^7.0.2",
+        "typescript-ast": "npm:typescript@^5.9.3"
       },
       "engines": {
         "node": ">=20.19"
@@ -2775,6 +2776,21 @@
         "@typescript/typescript-sunos-x64": "7.0.2",
         "@typescript/typescript-win32-arm64": "7.0.2",
         "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/typescript-ast": {
+      "name": "typescript",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "concurrently": "^9.1.2",
-    "typescript": "^7.0.2"
+    "typescript": "^7.0.2",
+    "typescript-ast": "npm:typescript@^5.9.3"
   }
 }

--- a/scripts/i18n-catalog-check.mjs
+++ b/scripts/i18n-catalog-check.mjs
@@ -12,7 +12,21 @@
  * in the file looking correct, is never looked up, and the app renders English
  * for ever. Nothing warns, because a catalogue is only ever read by key.
  */
-import ts from "typescript";
+/*
+ * The parser, not the compiler.
+ *
+ * TypeScript 7 is the native port: its package ships a `tsc` shim over a Go
+ * binary and nothing else, so `typescript` now exports `version` and
+ * `versionMajorMinor` and no compiler API at all. Every `ts.createSourceFile`
+ * in this directory started throwing "Cannot read properties of undefined
+ * (reading 'Latest')" the day the bump landed, and nothing noticed, because no
+ * workflow runs these.
+ *
+ * `typescript-ast` is an npm alias for the last TypeScript that carries the JS
+ * API (see package.json). It parses; `typescript` still type-checks and builds.
+ * Two entries, two jobs -- not a version someone forgot to remove.
+ */
+import ts from "typescript-ast";
 import { readFileSync, globSync } from "node:fs";
 
 const wanted = new Set();

--- a/scripts/i18n-coverage.mjs
+++ b/scripts/i18n-coverage.mjs
@@ -11,7 +11,21 @@
  * exits non-zero only with --check, so CI can be told to fail on regressions
  * later, once the number is low enough for that to mean something.
  */
-import ts from "typescript";
+/*
+ * The parser, not the compiler.
+ *
+ * TypeScript 7 is the native port: its package ships a `tsc` shim over a Go
+ * binary and nothing else, so `typescript` now exports `version` and
+ * `versionMajorMinor` and no compiler API at all. Every `ts.createSourceFile`
+ * in this directory started throwing "Cannot read properties of undefined
+ * (reading 'Latest')" the day the bump landed, and nothing noticed, because no
+ * workflow runs these.
+ *
+ * `typescript-ast` is an npm alias for the last TypeScript that carries the JS
+ * API (see package.json). It parses; `typescript` still type-checks and builds.
+ * Two entries, two jobs -- not a version someone forgot to remove.
+ */
+import ts from "typescript-ast";
 import { readFileSync, globSync } from "node:fs";
 
 /** Attributes a person reads. `className` and `key` are not among them. */

--- a/scripts/i18n-extract.mjs
+++ b/scripts/i18n-extract.mjs
@@ -12,7 +12,21 @@
  *   node scripts/i18n-extract.mjs <file...>   rewrite in place
  *   node scripts/i18n-extract.mjs --dry <file...>
  */
-import ts from "typescript";
+/*
+ * The parser, not the compiler.
+ *
+ * TypeScript 7 is the native port: its package ships a `tsc` shim over a Go
+ * binary and nothing else, so `typescript` now exports `version` and
+ * `versionMajorMinor` and no compiler API at all. Every `ts.createSourceFile`
+ * in this directory started throwing "Cannot read properties of undefined
+ * (reading 'Latest')" the day the bump landed, and nothing noticed, because no
+ * workflow runs these.
+ *
+ * `typescript-ast` is an npm alias for the last TypeScript that carries the JS
+ * API (see package.json). It parses; `typescript` still type-checks and builds.
+ * Two entries, two jobs -- not a version someone forgot to remove.
+ */
+import ts from "typescript-ast";
 import { readFileSync, writeFileSync } from "node:fs";
 
 const ATTRS = new Set(["title", "aria-label", "placeholder", "alt", "label", "hint", "confirmLabel", "description"]);

--- a/scripts/i18n-literals.mjs
+++ b/scripts/i18n-literals.mjs
@@ -18,7 +18,21 @@
  * string that is neither -- one no catalogue has a key for, which therefore
  * cannot be translated at all, however many languages ship.
  */
-import ts from "typescript";
+/*
+ * The parser, not the compiler.
+ *
+ * TypeScript 7 is the native port: its package ships a `tsc` shim over a Go
+ * binary and nothing else, so `typescript` now exports `version` and
+ * `versionMajorMinor` and no compiler API at all. Every `ts.createSourceFile`
+ * in this directory started throwing "Cannot read properties of undefined
+ * (reading 'Latest')" the day the bump landed, and nothing noticed, because no
+ * workflow runs these.
+ *
+ * `typescript-ast` is an npm alias for the last TypeScript that carries the JS
+ * API (see package.json). It parses; `typescript` still type-checks and builds.
+ * Two entries, two jobs -- not a version someone forgot to remove.
+ */
+import ts from "typescript-ast";
 import { readFileSync, globSync } from "node:fs";
 
 /* Where a string literal in this position is shown to somebody. */

--- a/scripts/i18n-strings.mjs
+++ b/scripts/i18n-strings.mjs
@@ -9,7 +9,21 @@
  * exists is dead weight, but a call with no key is an untranslated string
  * nobody noticed.
  */
-import ts from "typescript";
+/*
+ * The parser, not the compiler.
+ *
+ * TypeScript 7 is the native port: its package ships a `tsc` shim over a Go
+ * binary and nothing else, so `typescript` now exports `version` and
+ * `versionMajorMinor` and no compiler API at all. Every `ts.createSourceFile`
+ * in this directory started throwing "Cannot read properties of undefined
+ * (reading 'Latest')" the day the bump landed, and nothing noticed, because no
+ * workflow runs these.
+ *
+ * `typescript-ast` is an npm alias for the last TypeScript that carries the JS
+ * API (see package.json). It parses; `typescript` still type-checks and builds.
+ * Two entries, two jobs -- not a version someone forgot to remove.
+ */
+import ts from "typescript-ast";
 import { readFileSync, globSync } from "node:fs";
 
 const strings = new Set();


### PR DESCRIPTION
Four of the five i18n scripts have been dead since the TypeScript 7 bump. Found while adding catalogue entries in #327, where the gate that should have checked them couldn't run.

## Cause

TypeScript 7 is the native port. Its package ships a `tsc` shim over a Go binary and nothing else:

```
$ node -e "const ts=require('typescript'); console.log(Object.keys(ts))"
[ 'version', 'versionMajorMinor' ]
```

No `createSourceFile`, no `ScriptTarget`, no AST. Every script in `scripts/` that parses source has been throwing `Cannot read properties of undefined (reading 'Latest')` since `5.9.3 → 7.0.2`.

| script | before | after |
|---|---|---|
| `i18n-catalog-check` | broken | ✅ |
| `i18n-literals` | broken | ✅ |
| `i18n-coverage` | broken | ✅ |
| `i18n-strings` | broken | ✅ |
| `i18n-extract` | ✅ | ✅ |

Confirmed on a clean `main` checkout, so it wasn't from #327.

## Why an alias rather than a rewrite

There is no official TS7 API package — `@typescript/ast` and `@typescript/api` are both 404. The alternative was rewriting **493 lines across 5 files using 25 distinct AST calls**, including the JSX type guards, against a different tree shape — in tooling that has no tests of its own.

So `typescript-ast` is an npm alias for the last TypeScript carrying the JS API. **It parses; `typescript` still type-checks and builds.** Two entries, two jobs. Each script says so at the import, so the next reader doesn't delete one as a stray duplicate.

```json
"typescript": "^7.0.2",
"typescript-ast": "npm:typescript@^5.9.3"
```

Dev-only. Nothing changes at runtime or in the image.

## What the gate says now it can speak

Catalogues are **green** — `i18n:check` exits 0 and coverage is **100%** (964 wrapped, 0 remaining).

The "16 falling back to English" reported for every locale are not rot. They are placeholders, example domains, a product name, a licence identifier and the quote glyph:

```
"ihasmail.org"  "example.com"  "someone@example.com"  "name@example.com"
"https://"  "https://…"  "https://meet.example.com/…"  "•••"
"Stalwart Mail Server"  "AGPL-3.0-or-later · {source}"  "ihasmail test"
```

All correctly untranslated — translating them would be the bug.

The **41 stale keys per locale** (225 lines across the nine files) are real dead weight — entries translated but never looked up, mostly weekday names and a shortcuts list that has since changed. Left for their own change rather than bundled here.

## Checks

- all five scripts run
- `npm run typecheck` — clean, both packages
- `npm test` — 1160 web tests, 168 server tests, all passing
- `npm run build` — clean

## Worth knowing

**No workflow runs any of these.** `ci.yml` has one job, a Docker build. That's why a dead gate for nine languages went unnoticed — the only signal was running it by hand. Wiring `i18n:check` into CI would stop it rotting again, but that's a call about what CI is for rather than part of this fix, so it isn't here.